### PR TITLE
Trust SV qualities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ protobuf>=3.20
 pydantic>=2.5.2
 pyspark>=3.5.1
 python-dateutil>=2
-requests>=2.31.0
+requests>=2.32.0
 semsimian>=0.2.15
 tabulate>=0.8.9
 toml==0.10.2

--- a/src/talos/RunHailFilteringSV.py
+++ b/src/talos/RunHailFilteringSV.py
@@ -91,14 +91,15 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float | None = 0.03) -
     return mt.filter_rows((mt.info.MALE_AF[0] <= ac_threshold) & (mt.info.FEMALE_AF[0] <= ac_threshold))
 
 
-def rearrange_filters(mt: hl.MatrixTable) -> hl.MatrixTable:
+def rearrange_variantId(mt: hl.MatrixTable) -> hl.MatrixTable:
     """
-    Rearrange the variantId MT, and remove filter-failing variants
+    Rearrange the variantId MT
+    For now we do not filter out failing variant sites, we'll reserve this for per-sample quality failures
 
     Args:
         mt ():
     """
-    mt = mt.filter_rows(hl.is_missing(mt.filters) | (mt.filters.length() == 0))
+    # mt = mt.filter_rows(hl.is_missing(mt.filters) | (mt.filters.length() == 0))
     return mt.annotate_rows(info=mt.info.annotate(variantId=mt.variantId))
 
 
@@ -185,7 +186,7 @@ def main(mt_path: str, panelapp_path: str, pedigree: str, vcf_out: str):
     # apply blanket filters
     mt = filter_matrix_by_ac(mt, ac_threshold=config_retrieve(['RunHailFiltering', 'callset_af_sv_recessive']))
     mt = filter_matrix_by_af(mt, af_threshold=config_retrieve(['RunHailFiltering', 'callset_af_sv_recessive']))
-    mt = rearrange_filters(mt)
+    mt = rearrange_variantId(mt)
 
     # pre-filter the MT and rearrange fields for export
     mt = restructure_mt_by_gene(mt)

--- a/src/talos/RunHailFilteringSV.py
+++ b/src/talos/RunHailFilteringSV.py
@@ -91,7 +91,7 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float | None = 0.03) -
     return mt.filter_rows((mt.info.MALE_AF[0] <= ac_threshold) & (mt.info.FEMALE_AF[0] <= ac_threshold))
 
 
-def rearrange_variantId(mt: hl.MatrixTable) -> hl.MatrixTable:
+def rearrange_variant_id(mt: hl.MatrixTable) -> hl.MatrixTable:
     """
     Rearrange the variantId MT
     For now we do not filter out failing variant sites, we'll reserve this for per-sample quality failures
@@ -99,7 +99,6 @@ def rearrange_variantId(mt: hl.MatrixTable) -> hl.MatrixTable:
     Args:
         mt ():
     """
-    # mt = mt.filter_rows(hl.is_missing(mt.filters) | (mt.filters.length() == 0))
     return mt.annotate_rows(info=mt.info.annotate(variantId=mt.variantId))
 
 
@@ -186,7 +185,7 @@ def main(mt_path: str, panelapp_path: str, pedigree: str, vcf_out: str):
     # apply blanket filters
     mt = filter_matrix_by_ac(mt, ac_threshold=config_retrieve(['RunHailFiltering', 'callset_af_sv_recessive']))
     mt = filter_matrix_by_af(mt, af_threshold=config_retrieve(['RunHailFiltering', 'callset_af_sv_recessive']))
-    mt = rearrange_variantId(mt)
+    mt = rearrange_variant_id(mt)
 
     # pre-filter the MT and rearrange fields for export
     mt = restructure_mt_by_gene(mt)


### PR DESCRIPTION
# Fixes

  - We're missing some CNV calls due to whole sites being failed due to a failing Q score at any one component participant

## Proposed Changes

  - Scrap the Q score filter when processing SVs
  - ... that's it
  - CyVCF2 doesn't have a way to check out the Q scores on the VCFs coming out of SVAnnotate via Hail, so it's non-trivial to flag some of these Q failures later.