### PR TITLE
This PR removes the variant_class attribute

### DIFF
--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -323,9 +323,7 @@ def drop_useless_fields(mt: hl.MatrixTable) -> hl.MatrixTable:
     mt = mt.drop(*[field for field in USELESS_FIELDS if field in mt.row_value])
 
     # now drop most VEP fields
-    return mt.annotate_rows(
-        vep=hl.Struct(transcript_consequences=mt.vep.transcript_consequences, variant_class=mt.vep.variant_class),
-    )
+    return mt.annotate_rows(vep=hl.Struct(transcript_consequences=mt.vep.transcript_consequences))
 
 
 def remove_variants_outside_gene_roi(mt: hl.MatrixTable, green_genes: hl.SetExpression) -> hl.MatrixTable:
@@ -621,7 +619,6 @@ def vep_struct_to_csq(vep_expr: hl.expr.StructExpression) -> hl.expr.ArrayExpres
             {
                 'consequence': hl.delimit(element.consequence_terms, delimiter='&'),
                 'feature': element.transcript_id,
-                'variant_class': vep_expr.variant_class,
                 'ensp': element.protein_id,
                 'gene': element.gene_id,
                 'symbol': element.gene_symbol,

--- a/src/talos/VcfToMt.py
+++ b/src/talos/VcfToMt.py
@@ -47,7 +47,6 @@ RELEVANT_FIELDS: list[str] = [
     'protein_position',
     'sift',
     'symbol',
-    'variant_class',
 ]
 TYPE_UPDATES: dict[str, dict] = {
     'am_pathogenicity': {'insert': False, 'type': 'float'},
@@ -101,12 +100,10 @@ def csq_strings_into_hail_structs(csq_strings: list[str], mt: hl.MatrixTable) ->
         ),
     )
 
-    # add variant_class at the mt.vep level?
     # cdna, protein, and cds positions are all strings, potentially with ranges, so we need to convert them to ints
     # in some cases, the values can be "?-X" or "X-?", which are replaced with missing values
     return mt.annotate_rows(
         vep=mt.vep.annotate(
-            variant_class=mt.vep.transcript_consequences[0].variant_class,
             transcript_consequences=hl.map(
                 lambda x: x.annotate(
                     cdna_start=hl.if_else(

--- a/src/talos/data_model.py
+++ b/src/talos/data_model.py
@@ -75,7 +75,7 @@ schema = (
     'protein_id:str,gene_symbol_source:str,canonical:int32,cdna_start:int32,'
     'cds_start:int32,cds_end:int32,biotype:str,protein_start:int32,protein_end:int32,'
     'sift_score:float64,sift_prediction:str,polyphen_prediction:str,polyphen_score:'
-    'float64,mane_select:str,lof:str}>,variant_class:str},geneIds:set<str>'
+    'float64,mane_select:str,lof:str}>},geneIds:set<str>'
     '}'
 )
 
@@ -256,7 +256,6 @@ class VepVariant:
         dbnsfp: DBnsfp | None = None,
         clinvar: Clinvar | None = None,
         splice: Splice | None = None,
-        var_class: str = 'SNV',
     ):
         """
         VEP variant data model
@@ -269,12 +268,11 @@ class VepVariant:
             dbnsfp (DBnsfp): Revel/MutationTaster, or None
             clinvar (Clinvar): Clinvar data, or None
             splice (Splice): SpliceAI data, or None
-            var_class (str): ... SNV
         """
 
         self.data = (
             {
-                'vep': {'transcript_consequences': tx, 'variant_class': var_class},
+                'vep': {'transcript_consequences': tx},
                 'geneIds': {tx.gene_id for tx in tx},
                 'dbnsfp': dbnsfp or DBnsfp(),
                 'cadd': cadd or CADD(),

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -42,7 +42,7 @@ phenotype_match = ['6']
 
 [RunHailFiltering]
 # variables affecting how the VCF variants are parsed, and AnalysisVariant objects are populated
-csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'variant_class', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
+csq_string = ['consequence', 'symbol', 'gene', 'feature', 'mane_select', 'biotype', 'exon', 'hgvsc', 'hgvsp', 'cdna_position', 'cds_position', 'protein_position', 'ensp', 'lof', 'sift', 'polyphen', 'am_class', 'am_pathogenicity']
 
 # variables for the hail operations, including CSQ sets and filter thresholds
 ac_threshold = 0.01


### PR DESCRIPTION
Really minor QOL change to make redeployment easier

# Fixes

  - The artificial VCF generator, `data_model.py` currently generates variant data we can use in validation
  - This VCF generator currently includes the `variant_class` attribute, and elsewhere in Talos we require this annotation
  - This is an optional annotation from VEP, and we just pass it around, it's never used.
  - Requiring presence of variant_class means that we fail if a useless field is absent in variant data

## Proposed Changes

  - Removes `variant_class` from everywhere

## Checklist

- [x] Linting checks pass
