### PR TITLE
Follow-on Correction to AC & AF attributes

### DIFF
--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -280,7 +280,7 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float = 0.01) -> hl.Ma
     """
     min_callset_ac = 5
     return mt.filter_rows(
-        ((min_callset_ac >= mt.info.AC[0]) | (ac_threshold > mt.info.AC[0] / mt.AN))
+        ((min_callset_ac >= mt.info.AC[0]) | (ac_threshold > mt.info.AC[0] / mt.info.AN))
         | (mt.info.clinvar_talos == ONE_INT),
     )
 

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -249,8 +249,6 @@ def extract_annotations(mt: hl.MatrixTable) -> hl.MatrixTable:
 
     return mt.annotate_rows(
         info=mt.info.annotate(
-            AC=hl.or_else(mt.AC, MISSING_INT),
-            AN=hl.or_else(mt.AN, MISSING_INT),
             gnomad_ex_af=hl.or_else(mt.gnomad_exomes.AF, MISSING_FLOAT_LO),
             gnomad_ex_an=hl.or_else(mt.gnomad_exomes.AN, MISSING_INT),
             gnomad_ex_ac=hl.or_else(mt.gnomad_exomes.AC, MISSING_INT),
@@ -282,7 +280,8 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float = 0.01) -> hl.Ma
     """
     min_callset_ac = 5
     return mt.filter_rows(
-        ((min_callset_ac >= mt.AC) | (ac_threshold > mt.AC / mt.AN)) | (mt.info.clinvar_talos == ONE_INT),
+        ((min_callset_ac >= mt.info.AC[0]) | (ac_threshold > mt.info.AC[0] / mt.AN))
+        | (mt.info.clinvar_talos == ONE_INT),
     )
 
 

--- a/src/talos/VcfToMt.py
+++ b/src/talos/VcfToMt.py
@@ -383,9 +383,6 @@ def main(vcf_path: str, output_path: str, alpha_m: str | None = None):
     # checkpoint it locally to make everything faster
     mt = mt.checkpoint('checkpoint.mt', overwrite=True, _read_if_exists=True)
 
-    # take out some base fields - not sure why these should be at the top level. Expecting normalised
-    mt = mt.annotate_rows(AC=mt.info.AC[0], AF=mt.info.AF[0], AN=mt.info.AN)
-
     # re-shuffle the CSQ elements
     mt = csq_strings_into_hail_structs(vep_header_elements, mt)
 

--- a/src/talos/hail_audit.py
+++ b/src/talos/hail_audit.py
@@ -11,11 +11,13 @@ import hail as hl
 BASE_FIELDS_REQUIRED = [
     ('locus', hl.LocusExpression),
     ('alleles', hl.ArrayExpression),
-    ('AC', hl.Int32Expression),
-    ('AF', hl.Float64Expression),
-    ('AN', hl.Int32Expression),
 ]
 FIELDS_REQUIRED = {
+    'info': [
+        ('AC', hl.ArrayExpression),
+        # ('AF', hl.ArrayExpression),  # not explicitly required
+        ('AN', hl.Int32Expression),
+    ],
     'splice_ai': [
         ('delta_score', hl.Float32Expression),
         ('splice_consequence', hl.StringExpression),

--- a/src/talos/hail_audit.py
+++ b/src/talos/hail_audit.py
@@ -15,7 +15,6 @@ BASE_FIELDS_REQUIRED = [
 FIELDS_REQUIRED = {
     'info': [
         ('AC', hl.ArrayExpression),
-        # ('AF', hl.ArrayExpression),  # not explicitly required
         ('AN', hl.Int32Expression),
     ],
     'splice_ai': [

--- a/test/test_hail_broad_filters.py
+++ b/test/test_hail_broad_filters.py
@@ -11,13 +11,13 @@ from talos.RunHailFiltering import filter_matrix_by_ac, filter_on_quality_flags,
 @pytest.mark.parametrize(  # needs clinvar
     'ac,an,clinvar,threshold,rows',
     [
-        (1, 1, 0, 0.01, 1),
-        (6, 1, 0, 0.01, 0),
-        (6, 1, 1, 0.01, 1),
-        (6, 70, 0, 0.1, 1),
-        (50, 999999, 0, 0.01, 1),
-        (50, 50, 0, 0.01, 0),
-        (50, 50, 1, 0.01, 1),
+        ([1], 1, 0, 0.01, 1),
+        ([6], 1, 0, 0.01, 0),
+        ([6], 1, 1, 0.01, 1),
+        ([6], 70, 0, 0.1, 1),
+        ([50], 999999, 0, 0.01, 1),
+        ([50], 50, 0, 0.01, 0),
+        ([50], 50, 1, 0.01, 1),
     ],
 )
 def test_ac_filter_no_filt(ac: int, an: int, clinvar: int, threshold: float, rows: int, make_a_mt: hl.MatrixTable):
@@ -25,8 +25,13 @@ def test_ac_filter_no_filt(ac: int, an: int, clinvar: int, threshold: float, row
     run tests on the ac filtering method
     check that a clinvar pathogenic overrides the AC test
     """
-    matrix = make_a_mt.annotate_rows(AC=ac, AN=an)
-    matrix = matrix.annotate_rows(info=matrix.info.annotate(clinvar_talos=clinvar))
+    matrix = make_a_mt.annotate_rows(
+        info=make_a_mt.info.annotate(
+            clinvar_talos=clinvar,
+            AC=ac,
+            AN=an,
+        ),
+    )
 
     assert filter_matrix_by_ac(matrix, threshold).count_rows() == rows
 


### PR DESCRIPTION
# Fixes

  - Talos has been built on a dodgy data format supplied by seqr_loader, which won't translate well to non-CPG sites
  - Relates to https://github.com/populationgenomics/production-pipelines/pull/976

## Proposed Changes

  - refinement: Update the synthetic VCF generator script - remove some _in silico_ tools we don't use any more
  - fix: move the AC/AF/AN attributes into INFO, and update to the correct type
  - fix: RunHailFiltering.py expects to find single-entry arrays in info.AC
  - fix: hail_audit.py expects to find an array in info.AC, and an integer in info.AN