### PR TITLE
Fix comp het exclusion

### DIFF
--- a/src/talos/CPG/MakePhenopackets.py
+++ b/src/talos/CPG/MakePhenopackets.py
@@ -25,7 +25,7 @@ from metamist.graphql import gql, query
 from talos.static_values import get_logger
 
 HPO_KEY = 'HPO Terms (present)'
-HPO_RE = re.compile(r'HP:[0-9]+')
+HPO_RE = re.compile(r'HP:\d+')
 PARTICIPANT_QUERY = gql(
     """
 query MyQuery($project: String!, $sequencing_type: String!, $technology: String!) {

--- a/src/talos/GeneratePanelData.py
+++ b/src/talos/GeneratePanelData.py
@@ -20,7 +20,7 @@ from talos.models import ParticipantHPOPanels, PhenoPacketHpo, PhenotypeMatchedP
 from talos.static_values import get_logger
 from talos.utils import get_json_response, read_json_from_path
 
-HPO_RE = re.compile(r'HP:[0-9]+')
+HPO_RE = re.compile(r'HP:\d+')
 
 PANELAPP_HARD_CODED_DEFAULT = 'https://panelapp.agha.umccr.org/api/v1/panels'
 PANELAPP_HARD_CODED_BASE_PANEL = 137

--- a/src/talos/HPOFlagging.py
+++ b/src/talos/HPOFlagging.py
@@ -67,7 +67,7 @@ def parse_genes_to_hpo(g2p_file: str, ensg2symbol: str, genes: set[str]) -> dict
     gene_to_phenotype: dict[str, set[str]] = defaultdict(set)
     with open(g2p_file, encoding='utf-8') as f:
         for line in f:
-            ncbi_gene_id, gene_symbol, hpo_id, hpo_name, frequency, disease_id = line.split('\t')
+            _, gene_symbol, hpo_id, _, _, _ = line.split('\t')
             if gene_symbol in ensg_map and ensg_map[gene_symbol] in genes:
                 gene_to_phenotype.setdefault(ensg_map[gene_symbol], set()).add(hpo_id)
     return gene_to_phenotype
@@ -109,7 +109,6 @@ def annotate_phenotype_matches(result_object: ResultData, gen_phen: dict[str, se
         result_object (ResultData):
         gen_phen (dict): mapping of ENSGs to relevant HPO terms
     """
-
     semantic_match = config_retrieve(['HPOFlagging', 'semantic_match'], False)
 
     min_similarity: float = config_retrieve(['HPOFlagging', 'min_similarity'])

--- a/src/talos/ValidateMOI.py
+++ b/src/talos/ValidateMOI.py
@@ -119,6 +119,8 @@ def apply_moi_to_variants(
     results = []
 
     for gene, variants in variant_dict.items():
+        if gene != 'ENSG00000197249':
+            continue
         comp_het_dict = find_comp_hets(var_list=variants, pedigree=pedigree)
 
         # extract the panel data specific to this gene
@@ -480,7 +482,7 @@ def main(
     all_samples: set[str] = small_vcf_samples.union(sv_vcf_samples)
 
     # obtain a set of all contigs with variants
-    for contig in canonical_contigs_from_vcf(vcf_opened):
+    for contig in ['chr14']:  # canonical_contigs_from_vcf(vcf_opened):
         # assemble {gene: [var1, var2, ..]}
         contig_dict = gather_gene_dict_from_contig(
             contig=contig,

--- a/src/talos/ValidateMOI.py
+++ b/src/talos/ValidateMOI.py
@@ -119,8 +119,6 @@ def apply_moi_to_variants(
     results = []
 
     for gene, variants in variant_dict.items():
-        if gene != 'ENSG00000197249':
-            continue
         comp_het_dict = find_comp_hets(var_list=variants, pedigree=pedigree)
 
         # extract the panel data specific to this gene
@@ -482,7 +480,7 @@ def main(
     all_samples: set[str] = small_vcf_samples.union(sv_vcf_samples)
 
     # obtain a set of all contigs with variants
-    for contig in ['chr14']:  # canonical_contigs_from_vcf(vcf_opened):
+    for contig in canonical_contigs_from_vcf(vcf_opened):
         # assemble {gene: [var1, var2, ..]}
         contig_dict = gather_gene_dict_from_contig(
             contig=contig,

--- a/src/talos/ValidateMOI.py
+++ b/src/talos/ValidateMOI.py
@@ -486,7 +486,6 @@ def main(
             contig=contig,
             variant_source=vcf_opened,
             sv_sources=sv_opened,
-            singletons=bool('singleton' in pedigree),
         )
 
         result_list.extend(
@@ -524,7 +523,7 @@ def main(
     results_model = clean_and_filter(results_model, result_list, panelapp_data, pheno_panels)
 
     # annotate previously seen results using cumulative data file(s)
-    filter_results(results_model, singletons=bool('singleton' in pedigree))
+    filter_results(results_model)
 
     # write the output to long term storage using Pydantic
     # validate the model against the schema, then write the result if successful

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -283,7 +283,9 @@ class SmallVariant(VariantCommon):
         Returns:
             return a flag if this sample has low read depth
         """
-        if self.depths[sample] < threshold and not var_is_cat_1:
+        if var_is_cat_1:
+            return set()
+        if self.depths[sample] < threshold:
             return {'Low Read Depth'}
         return set()
 

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -455,8 +455,6 @@ class RecessiveAutosomalCH(BaseMoi):
 
         # if hets are present, try and find support
         for sample_id in principal.het_samples:
-            if sample_id != 'CPG259705':
-                continue
             # skip primary analysis for unaffected members
             # this sample must be categorised - check Cat 4 contents
             if (

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -70,7 +70,8 @@ def check_for_second_hit(
 
 class MOIRunner:
     """
-    pass
+    The abstract class for a single MOI runner
+    This will be instantiated once per MOI, and run once per related gene, on the collection of all variants in the gene
     """
 
     def __init__(self, pedigree: Pedigree, target_moi: str):

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -264,18 +264,22 @@ class BaseMoi:
         }
 
     @staticmethod
-    def check_frequency_passes(info: dict, thresholds: dict[str, int | float]) -> bool:
+    def check_frequency_passes(info: dict, thresholds: dict[str, int | float], permit_clinvar: bool = True) -> bool:
         """
         Method to check multiple info keys against a single threshold
         This just reduces the line count, as this is called a bunch of times
+        By default we always let clinvar pathogenic variants pass
 
         Args:
             info (): the dict of values for this dict
             thresholds (): the dict of keys - thresholds to test against
+            permit_clinvar (bool): if True, always allow clinvar pathogenic variants to pass
 
         Returns:
             True if any of the info attributes is above the threshold
         """
+        if permit_clinvar and info.get('categoryboolean1'):
+            return True
         return all(info.get(key, 0) <= test for key, test in thresholds.items())
 
     def check_comp_het(self, sample_id: str, variant_1: VARIANT_MODELS, variant_2: VARIANT_MODELS) -> bool:
@@ -353,7 +357,10 @@ class DominantAutosomal(BaseMoi):
 
         # reject support for dominant MOI, apply checks based on var type
         if principal.support_only or not (
-            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
+            self.check_frequency_passes(
+                principal.info,
+                self.freq_tests[principal.__class__.__name__],
+            )
         ):
             return classifications
 
@@ -440,14 +447,16 @@ class RecessiveAutosomalCH(BaseMoi):
         classifications = []
 
         # remove if too many homs are present in population databases
-        if not (
-            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
-            or principal.info.get('categoryboolean1')
+        if not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
         ):
             return classifications
 
         # if hets are present, try and find support
         for sample_id in principal.het_samples:
+            if sample_id != 'CPG259705':
+                continue
             # skip primary analysis for unaffected members
             # this sample must be categorised - check Cat 4 contents
             if (
@@ -468,11 +477,9 @@ class RecessiveAutosomalCH(BaseMoi):
                     sample_id,
                     self.minimum_depth,
                     partner_variant.info.get('categoryboolean1'),
-                ) or not (
-                    self.check_frequency_passes(
-                        partner_variant.info,
-                        self.freq_tests[partner_variant.__class__.__name__],
-                    )
+                ) or not self.check_frequency_passes(
+                    partner_variant.info,
+                    self.freq_tests[partner_variant.__class__.__name__],
                 ):
                     continue
 
@@ -534,9 +541,9 @@ class RecessiveAutosomalHomo(BaseMoi):
         classifications = []
 
         # remove if too many homs are present in population databases
-        if principal.support_only or not (
-            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
-            or principal.info.get('categoryboolean1')
+        if principal.support_only or not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
         ):
             return classifications
 
@@ -633,7 +640,10 @@ class XDominant(BaseMoi):
 
         # never apply dominant MOI to support variants
         # more stringent Pop.Freq checks for dominant - hemi restriction
-        if not self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__]):
+        if not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
+        ):
             return classifications
 
         # all samples which have a variant call
@@ -729,7 +739,10 @@ class XPseudoDominantFemale(BaseMoi):
 
         # never apply dominant MOI to support variants
         # more stringent Pop.Freq checks for dominant - hemi restriction
-        if not self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__]):
+        if not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
+        ):
             return classifications
 
         # all females which have a variant call
@@ -822,7 +835,10 @@ class XRecessiveMale(BaseMoi):
         classifications = []
 
         # remove from analysis if too many homs are present in population databases
-        if not self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__]):
+        if not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
+        ):
             return classifications
 
         # combine het and hom here, we don't trust the variant callers
@@ -900,9 +916,9 @@ class XRecessiveFemaleHom(BaseMoi):
         classifications = []
 
         # remove from analysis if too many homs are present in population databases
-        if principal.support_only or not (
-            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
-            or principal.info.get('categoryboolean1')
+        if principal.support_only or not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
         ):
             return classifications
 
@@ -983,9 +999,9 @@ class XRecessiveFemaleCH(BaseMoi):
         classifications = []
 
         # remove from analysis if too many homs are present in population databases
-        if not (
-            self.check_frequency_passes(principal.info, self.freq_tests[principal.__class__.__name__])
-            or principal.info.get('categoryboolean1')
+        if not self.check_frequency_passes(
+            principal.info,
+            self.freq_tests[principal.__class__.__name__],
         ):
             return classifications
         het_females = {sam for sam in principal.het_samples if self.pedigree.by_id[sam].sex == '2'}
@@ -1009,9 +1025,9 @@ class XRecessiveFemaleCH(BaseMoi):
                 require_non_support=principal.sample_support_only(sample_id),
             ):
                 # allow for de novo check - also screen out high-AF partners
-                if not partner.sample_category_check(sample_id, allow_support=True) or not (
-                    self.check_frequency_passes(partner.info, self.freq_tests[partner.__class__.__name__])
-                    or partner.info.get('categoryboolean1')
+                if not partner.sample_category_check(sample_id, allow_support=True) or not self.check_frequency_passes(
+                    partner.info,
+                    self.freq_tests[partner.__class__.__name__],
                 ):
                     continue
 

--- a/src/talos/templates/sample_index.html.jinja
+++ b/src/talos/templates/sample_index.html.jinja
@@ -28,7 +28,7 @@
 
     {# Results #}
     <div>
-        <a href="{{ index_path }}" class="btn btn-secondary" role="button">Link back to whole-cohort page</a>
+        <button onclick="location.href='{{ index_path }}'" type="button">Link back to whole-cohort page</button>
 
         </br>
         ClinvArbitration, CPG's re-aggregation of ClinVar submissions: <a href="https://github.com/populationgenomics/ClinvArbitration" target="_blank">https://github.com/populationgenomics/ClinvArbitration</a>

--- a/src/talos/utils.py
+++ b/src/talos/utils.py
@@ -153,9 +153,7 @@ def identify_file_type(file_path: str) -> FileTypes | Exception:
     pl_filepath = Path(file_path)
 
     # pull all extensions (e.g. .vcf.bgz will be split into [.vcf, .bgz]
-    extensions = pl_filepath.suffixes
-
-    if not len(extensions) > 0:
+    if not (extensions := pl_filepath.suffixes):
         raise ValueError('cannot identify input type from extensions')
 
     if extensions[-1] == '.ht':

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -413,14 +413,14 @@ def test_x_dominant_male_hom_passes(pedigree_path):
 
 
 @pytest.mark.parametrize(
-    'info',
+    'info,wins',
     [
-        {'gnomad_af': 0.1, 'gene_id': 'TEST1', 'categoryboolean1': True},
-        {'gnomad_hom': 2, 'gene_id': 'TEST1', 'categoryboolean1': True},
-        {'gnomad_hemi': 3, 'gene_id': 'TEST1', 'categoryboolean1': True},
+        ({'gnomad_af': 0.1, 'gene_id': 'TEST1', 'categoryboolean1': True}, 1),
+        ({'gnomad_hom': 2, 'gene_id': 'TEST1', 'categoryboolean1': True}, 1),
+        ({'gnomad_hemi': 3, 'gene_id': 'TEST1', 'categoryboolean1': False}, 0),
     ],
 )
-def test_x_dominant_info_fails(info, pedigree_path):
+def test_x_dominant_info_fails(info: dict, wins: int, pedigree_path):
     """
     check for info dict exclusions
     """
@@ -430,9 +430,11 @@ def test_x_dominant_info_fails(info, pedigree_path):
         coordinates=TEST_COORDS_X_1,
         boolean_categories=['categoryboolean1'],
         transcript_consequences=[],
+        depths={'male': 100},
     )
+    print(passing_variant)
     x_dom = XDominant(pedigree=make_flexible_pedigree(pedigree_path))
-    assert len(x_dom.run(passing_variant)) == 0
+    assert len(x_dom.run(passing_variant)) == wins
 
 
 def test_x_dominant_female_inactivation_passes(pedigree_path):


### PR DESCRIPTION
# Fixes

  - It's been noted that we occasionally let one variant of a comp-het pair slide off the report. This doesn't make sense, as a pairing between two variants should be symmetrical in terms of reaching the report.
  - I originally assumed this was related to the report changes; we no longer create a 'latest-only' report, but when we did there was some logic around "keep all variants which were new in the latest round, and any variants they pair with"
  - The real fault here was that the `check_frequency_passes` method (which permits/blocks variants based on gnomAD frequencies) was usually combined with an escape "always allow if pathogenic in ClinVar".
  - This ClinVar escape only applied to the 'principal' variant in a pair, and not the partner:

```
Variant 1 is common, and pathogenic in ClinVar
Variant 2 is rare, and not in ClinVar
Variant 1 can be the 'principal', as the first frequency test permits ClinVar variants through. 
   - Variant 2 passes as a partner because it's sufficiently rare. 
   - Variant1::Variant2 is a permitted comp-het
When Variant 2 is the 'principal' it's sufficiently rare to pass the test
   - Variant 1 fails the comp-het test as it's too common, and the logic didn't allow for ClinVar status. 
   - Variant2::Variant1 doesn't reach the report.
```

I'm still unsure if this is a changed behaviour, or just a rare occurrence that we haven't paid enough attention to. The logic in this region is unchanged in the last ~7 months, and even then it was restructured, but this bug was from even earlier.

## Proposed Changes

  - Removes the concept of 'singleton' analysis (artificially stripping de novo status etc.). This can be done by providing a singleton pedigree, this is an opportunity to smooth out some logic
  - Changed some more things that SonarLint was shouting at me for
  - `check_frequency_passes` has a new argument - permit_clinvar, defaulting to True. If True, we check if the variant is Pathogenic in ClinVar; if so, the check automatically passes.
  - This removes the need to check "check_frequency_passes or clinvar Pathogenic" elsewhere, bundling both behaviours into the same method

## Checklist

- [x] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
