### PR TITLE
Stricter Variant filtering

### DIFF
--- a/src/talos/CreateTalosHTML.py
+++ b/src/talos/CreateTalosHTML.py
@@ -569,7 +569,9 @@ class Variant:
             else []
         )
 
+        # make these accessible in the report/presentation
         self.var_data.info['alpha_missense_max'] = max(am_scores) if am_scores else 'missing'
+        self.exomiser_results = report_variant.exomiser_results
 
         # this is the weird gnomad callset ID
         if (

--- a/src/talos/CreateTalosHTML.py
+++ b/src/talos/CreateTalosHTML.py
@@ -247,7 +247,11 @@ class HTMLBuilder:
                     html_builder=self,
                 ),
             )
+
         self.samples.sort(key=lambda x: x.ext_id)
+
+        # if a variant has any filters (AB Ratio, Low Depth), the variant will only be reported if it's in this list
+        self.allow_filters: set[str] = set(config_retrieve(['CreateTalosHTML', 'allow_filters'], []))
 
     def get_summary_stats(self) -> tuple[pd.DataFrame, list[str], list[dict]]:
         """
@@ -444,7 +448,12 @@ class Sample:
         self.seqr_id = html_builder.seqr.get(name, None)
         self.report_url = f'{indi_folder}/{self.name}.html'
 
-        # Ingest variants excluding any on the forbidden gene list
+        # exclude any on the forbidden gene list
+        variants = [var for var in variants if not variant_in_forbidden_gene(var, html_builder.forbidden_genes)]
+
+        # drop variants which fail quality/depth filters, unless all filters are explicitly permitted
+        variants = [var for var in variants if not (var.flags - html_builder.allow_filters)]
+
         self.variants = [
             Variant(
                 report_variant,

--- a/src/talos/CreateTalosHTML.py
+++ b/src/talos/CreateTalosHTML.py
@@ -250,9 +250,6 @@ class HTMLBuilder:
 
         self.samples.sort(key=lambda x: x.ext_id)
 
-        # if a variant has any filters (AB Ratio, Low Depth), the variant will only be reported if it's in this list
-        self.allow_filters: set[str] = set(config_retrieve(['CreateTalosHTML', 'allow_filters'], []))
-
     def get_summary_stats(self) -> tuple[pd.DataFrame, list[str], list[dict]]:
         """
         Run the numbers across all variant categories
@@ -448,11 +445,14 @@ class Sample:
         self.seqr_id = html_builder.seqr.get(name, None)
         self.report_url = f'{indi_folder}/{self.name}.html'
 
+        # if a variant has any filters (AB Ratio, Low Depth), the variant will only be reported if it's in this list
+        self.allow_filters: set[str] = set(config_retrieve(['CreateTalosHTML', 'allow_filters'], []))
+
         # exclude any on the forbidden gene list
         variants = [var for var in variants if not variant_in_forbidden_gene(var, html_builder.forbidden_genes)]
 
         # drop variants which fail quality/depth filters, unless all filters are explicitly permitted
-        variants = [var for var in variants if not (var.flags - html_builder.allow_filters)]
+        variants = [var for var in variants if not (var.flags - self.allow_filters)]
 
         self.variants = [
             Variant(

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -349,7 +349,7 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float = 0.01) -> hl.Ma
     """
     Remove variants with AC in joint-call over threshold
     Will never remove variants with 5 or fewer instances
-    Also overridden by having a Clinvar Pathogenic anno.
+    This is now more strict, not permitting clinvar pathogenics to pass through
 
     Args:
         mt (hl.MatrixTable):
@@ -359,14 +359,7 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float = 0.01) -> hl.Ma
         (unless overridden by clinvar path)
     """
     min_callset_ac = 5
-    return mt.filter_rows(
-        ((min_callset_ac >= mt.info.AC[0]) | (ac_threshold > mt.info.AC[0] / mt.info.AN))
-        | (
-            (mt.info.clinvar_talos == ONE_INT)
-            | (mt.info.categorybooleansvdb == ONE_INT)
-            | (mt.info.categorydetailsexomiser != MISSING_STRING)
-        ),
-    )
+    return mt.filter_rows((min_callset_ac >= mt.info.AC[0]) | (ac_threshold > mt.info.AC[0] / mt.info.AN))
 
 
 def filter_to_population_rare(mt: hl.MatrixTable) -> hl.MatrixTable:

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -57,6 +57,9 @@ max_parent_ab = 0.05
 minimum_depth = 10
 spliceai = 0.5
 
+# if true, we retain all common-in-callset variants if they have been prioritised as pathogenic (ClinVar, Exomiser)
+allow_clinvar_common = false
+
 [RunHailFiltering.cores]
 small_variants = 8
 

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -82,7 +82,7 @@ seqr_project = "e.g. COHORT_project_id"
 
 # a variant will only be permitted into the final report if it has no `flags` attached, or if all the attached
 # flags fully overlap with this list. Examples are "AB Ratio" for allelic balance, or "Low Read Depth"
-allow_filters = []
+allow_filters = ['Ambiguous Cat.1 MOI', 'Affected female with heterozygous variant in XLR gene']
 
 [HPOFlagging]
 # this section relates to phenotype-matching the final variant set

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -77,6 +77,10 @@ seqr_lookup = "e.g. gs://cpg-COHORT-test/reanalysis/parsed_seqr.json"
 seqr_instance = "e.g. https://seqr.populationgenomics.org.au"
 seqr_project = "e.g. COHORT_project_id"
 
+# a variant will only be permitted into the final report if it has no `flags` attached, or if all the attached
+# flags fully overlap with this list. Examples are "AB Ratio" for allelic balance, or "Low Read Depth"
+allow_filters = []
+
 [HPOFlagging]
 # this section relates to phenotype-matching the final variant set
 

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -271,11 +271,13 @@ class SmallVariant(VariantCommon):
         """
         gets all report flags for this sample - currently only one flag
         """
-        return self.check_ab_ratio(sample) | self.check_read_depth(sample)
+        return self.check_ab_ratio(sample) | self.check_read_depth_strict(sample)
 
     def check_read_depth(self, sample: str, threshold: int = 10, var_is_cat_1: bool = False) -> set[str]:
         """
         flag low read depth for this sample
+        this version is used to determine whether a variant should be considered for _this_ sample
+        in this situation we pass variants in clinvar, regardless of read depth
 
         Args:
             sample (str): sample ID matching VCF
@@ -287,6 +289,19 @@ class SmallVariant(VariantCommon):
         """
         if var_is_cat_1:
             return set()
+        return self.check_read_depth_strict(sample, threshold)
+
+    def check_read_depth_strict(self, sample: str, threshold: int = 10) -> set[str]:
+        """
+        flag low read depth for this sample - doesn't care if it's in ClinVar
+
+        Args:
+            sample (str): sample ID matching VCF
+            threshold (int): cut-off for flagging as a failure
+
+        Returns:
+            return a flag if this sample has low read depth
+        """
         if self.depths[sample] < threshold:
             return {'Low Read Depth'}
         return set()

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -183,7 +183,6 @@ class VariantCommon(BaseModel):
         categories: set[str] = set()
         for category in self.sample_categories:
             cat_samples = self.info[category]
-            print(cat_samples, category)
             if not isinstance(cat_samples, list):
                 raise TypeError(f'Sample categories should be a list: {cat_samples}')
             if sample in cat_samples:
@@ -370,6 +369,8 @@ class ReportVariant(BaseModel):
     support_vars: set[str] = Field(default_factory=set)
     # log whether there was an increase in ClinVar star rating since the last run
     clinvar_increase: bool = Field(default=False)
+    # exomiser results - I'd like to store this in a cleaner way in future
+    exomiser_results: list[str] = Field(default_factory=list)
 
     def __eq__(self, other):
         """

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -334,7 +334,7 @@ class DominantAutosomal(BaseMoi):
         # prepare the AF test dicts
         self.freq_tests = {
             SmallVariant.__name__: {key: self.hom_threshold for key in INFO_HOMS}
-            | {'gnomad_ac': self.ac_threshold, 'gnomad_af': self.ad_threshold},
+            | {'gnomad_ac': self.ac_threshold, 'gnomad_af': self.ad_threshold, 'af': self.ad_threshold},
             StructuralVariant.__name__: {'af': self.sv_af_threshold, SV_AF_KEY: self.sv_af_threshold},
         }
         super().__init__(pedigree=pedigree, applied_moi=applied_moi)
@@ -608,7 +608,7 @@ class XDominant(BaseMoi):
         self.freq_tests = {
             SmallVariant.__name__: {key: self.hom_threshold for key in INFO_HOMS}
             | {key: self.hemi_threshold for key in INFO_HEMI}
-            | {'gnomad_ac': self.ac_threshold, 'gnomad_af': self.ad_threshold},
+            | {'gnomad_ac': self.ac_threshold, 'gnomad_af': self.ad_threshold, 'af': self.ad_threshold},
             StructuralVariant.__name__: {key: self.hom_threshold for key in SV_HOMS}
             | {key: self.hemi_threshold for key in SV_HEMI},
         }

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -15,6 +15,7 @@ from talos.utils import X_CHROMOSOME, CompHetDict
 
 # config keys to use for dominant MOI tests
 CALLSET_AF_SV_DOMINANT = 'callset_af_sv_dominant'
+CB1 = 'categoryboolean1'
 GNOMAD_RARE_THRESHOLD = 'gnomad_dominant'
 GNOMAD_AD_AC_THRESHOLD = 'gnomad_max_ac_dominant'
 GNOMAD_DOM_HOM_THRESHOLD = 'gnomad_max_homs_dominant'
@@ -174,7 +175,7 @@ class BaseMoi:
                 self.pedigree.by_id[sample_id].affected == '2'
                 and variant.sample_category_check(sample_id, allow_support=False)
             )
-        ) or variant.check_read_depth(sample_id, self.minimum_depth, var_is_cat_1=variant.info.get('categoryboolean1')):
+        ) or variant.check_read_depth(sample_id, self.minimum_depth, var_is_cat_1=variant.info.get(CB1)):
             return True
         return False
 
@@ -278,9 +279,9 @@ class BaseMoi:
         Returns:
             True if any of the info attributes are above the threshold, unless we use a clinvar escape
         """
-        if permit_clinvar and info.get('categoryboolean1'):
+        if permit_clinvar and info.get(CB1):
             return False
-        return any(info.get(key, 0) >= test for key, test in thresholds.items())
+        return any(info.get(key, 0) > test for key, test in thresholds.items())
 
     @staticmethod
     def check_callset_af_fails(info: dict, threshold: float) -> bool:
@@ -300,7 +301,7 @@ class BaseMoi:
         """
 
         min_ac = 5
-        if info.get('ac', 0) < min_ac:
+        if info.get('ac', 0) <= min_ac:
             return False
 
         return info.get('af', 0.0) >= threshold
@@ -402,7 +403,7 @@ class DominantAutosomal(BaseMoi):
                 principal.check_read_depth(
                     sample_id,
                     self.minimum_depth,
-                    var_is_cat_1=principal.info.get('categoryboolean1'),
+                    var_is_cat_1=principal.info.get(CB1),
                 )
             ):
                 continue
@@ -487,7 +488,7 @@ class RecessiveAutosomalCH(BaseMoi):
                     self.pedigree.by_id[sample_id].affected == '2'
                     and principal.sample_category_check(sample_id, allow_support=True)
                 )
-            ) or (principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1'))):
+            ) or (principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1))):
                 continue
 
             for partner_variant in check_for_second_hit(
@@ -499,7 +500,7 @@ class RecessiveAutosomalCH(BaseMoi):
                 if partner_variant.check_read_depth(
                     sample_id,
                     self.minimum_depth,
-                    partner_variant.info.get('categoryboolean1'),
+                    partner_variant.info.get(CB1),
                 ) or self.check_frequency_fails(
                     partner_variant.info,
                     self.freq_tests[partner_variant.__class__.__name__],
@@ -579,7 +580,7 @@ class RecessiveAutosomalHomo(BaseMoi):
                     self.pedigree.by_id[sample_id].affected == '2'
                     and principal.sample_category_check(sample_id, allow_support=False)
                 )
-            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1)):
                 continue
 
             # check if this is a possible candidate for homozygous inheritance
@@ -682,7 +683,7 @@ class XDominant(BaseMoi):
                     principal.sample_category_check(sample_id, allow_support=False)
                     and self.pedigree.by_id[sample_id].affected == '2'
                 )
-            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1)):
                 continue
 
             # check if this is a candidate for dominant inheritance
@@ -781,7 +782,7 @@ class XPseudoDominantFemale(BaseMoi):
                     principal.sample_category_check(sample_id, allow_support=False)
                     and self.pedigree.by_id[sample_id].affected == '2'
                 )
-            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1)):
                 continue
 
             # check if this is a candidate for dominant inheritance
@@ -879,7 +880,7 @@ class XRecessiveMale(BaseMoi):
                     self.pedigree.by_id[sample_id].affected == '2'
                     and principal.sample_category_check(sample_id, allow_support=False)
                 )
-            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1)):
                 continue
 
             # check if this is a possible candidate for homozygous inheritance
@@ -956,7 +957,7 @@ class XRecessiveFemaleHom(BaseMoi):
                     self.pedigree.by_id[sample_id].affected == '2'
                     and principal.sample_category_check(sample_id, allow_support=False)
                 )
-            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1)):
                 continue
 
             # check if this is a possible candidate for homozygous inheritance
@@ -1039,7 +1040,7 @@ class XRecessiveFemaleCH(BaseMoi):
                     self.pedigree.by_id[sample_id].affected == '2'
                     and principal.sample_category_check(sample_id, allow_support=True)
                 )
-            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get('categoryboolean1')):
+            ) or principal.check_read_depth(sample_id, self.minimum_depth, principal.info.get(CB1)):
                 continue
 
             for partner in check_for_second_hit(
@@ -1056,7 +1057,7 @@ class XRecessiveFemaleCH(BaseMoi):
                     continue
 
                 # check for minimum depth in partner
-                if partner.check_read_depth(sample_id, self.minimum_depth, partner.info.get('categoryboolean1')):
+                if partner.check_read_depth(sample_id, self.minimum_depth, partner.info.get(CB1)):
                     continue
 
                 if not self.check_comp_het(sample_id=sample_id, variant_1=principal, variant_2=partner):

--- a/src/talos/templates/variant_table_row.html.jinja
+++ b/src/talos/templates/variant_table_row.html.jinja
@@ -129,7 +129,7 @@
     <td>
         {# Exomiser #}
         {% if 'exomiser' in variant.categories %}
-            {% for exomiser_entry in variant.var_data.info.exomiser %}
+            {% for exomiser_entry in variant.exomiser_results %}
                 {{exomiser_entry}}
             {% endfor %}
         {% endif %}

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -157,23 +157,17 @@ def test_green_from_panelapp():
 
 
 @pytest.mark.parametrize(
-    'exomes,genomes,clinvar,svdb,exomiser,length',
+    'exomes,genomes,length',
     [
-        [0, 0, 0, 0, 'missing', 1],
-        [1.0, 0, 0, 0, 'missing', 0],
-        [1.0, 0, 0, 0, 'present', 1],
-        [1.0, 0, 0, 1, 'missing', 1],
-        [1.0, 0, 1, 0, 'missing', 1],
-        [0.0001, 0.0001, 0, 0, 'missing', 1],
-        [0.0001, 0.0001, 1, 0, 'missing', 1],
+        [0, 0, 1],
+        [1.0, 0, 0],
+        [0.0001, 0.0001, 1],
+        [0.0001, 0.0001, 1],
     ],
 )
 def test_filter_rows_for_rare(
     exomes: float,
     genomes: float,
-    clinvar: int,
-    svdb: int,
-    exomiser: str,
     length: int,
     make_a_mt,
 ):
@@ -183,11 +177,6 @@ def test_filter_rows_for_rare(
     anno_matrix = make_a_mt.annotate_rows(
         gnomad_genomes=hl.Struct(AF=genomes),
         gnomad_exomes=hl.Struct(AF=exomes),
-        info=make_a_mt.info.annotate(
-            clinvar_talos=clinvar,
-            categorybooleansvdb=svdb,
-            categorydetailsexomiser=exomiser,
-        ),
     )
     matrix = filter_to_population_rare(anno_matrix)
     assert matrix.count_rows() == length

--- a/test/test_hail_filters.py
+++ b/test/test_hail_filters.py
@@ -9,43 +9,26 @@ from talos.RunHailFiltering import filter_matrix_by_ac, filter_on_quality_flags,
 
 
 @pytest.mark.parametrize(  # needs clinvar
-    'ac,an,clinvar,svdb,exomiser,threshold,rows',
+    'ac,an,threshold,rows',
     [
-        ([1], 1, 0, 0, 'missing', 0.01, 1),
-        ([6], 1, 0, 0, 'missing', 0.01, 0),
-        ([6], 1, 0, 1, 'missing', 0.01, 1),
-        ([6], 1, 0, 0, 'present', 0.01, 1),
-        ([6], 1, 1, 0, 'missing', 0.01, 1),
-        ([6], 70, 0, 0, 'missing', 0.1, 1),
-        ([50], 999999, 0, 0, 'missing', 0.01, 1),
-        ([50], 50, 0, 0, 'missing', 0.01, 0),
-        ([50], 50, 1, 0, 'missing', 0.01, 1),
+        ([1], 1, 0.01, 1),
+        ([6], 1, 0.01, 0),
+        ([6], 70, 0.1, 1),
+        ([50], 999999, 0.01, 1),
+        ([50], 50, 0.01, 0),
     ],
 )
 def test_ac_filter_no_filt(
     ac: int,
     an: int,
-    clinvar: int,
-    svdb: str,
-    exomiser: str,
     threshold: float,
     rows: int,
     make_a_mt: hl.MatrixTable,
 ):
     """
     run tests on the ac filtering method
-    check that a clinvar pathogenic overrides the AC test
     """
-    matrix = make_a_mt.annotate_rows(
-        info=make_a_mt.info.annotate(
-            clinvar_talos=clinvar,
-            AC=ac,
-            AN=an,
-            categorybooleansvdb=svdb,
-            categorydetailsexomiser=exomiser,
-        ),
-    )
-
+    matrix = make_a_mt.annotate_rows(info=make_a_mt.info.annotate(AC=ac, AN=an))
     assert filter_matrix_by_ac(matrix, threshold).count_rows() == rows
 
 

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -100,10 +100,17 @@ def test_dominant_autosomal_passes(pedigree_path):
     :return:
     """
 
-    info_dict = {'gnomad_af': 0.0001, 'af': 0.0001, 'gnomad_ac': 0, 'gnomad_hom': 0, 'cat1': True, 'gene_id': 'TEST1'}
+    info_dict = {
+        'gnomad_af': 0.0001,
+        'af': 0.0001,
+        'gnomad_ac': 0,
+        'gnomad_hom': 0,
+        'categoryboolean1': True,
+        'gene_id': 'TEST1',
+    }
 
     # attributes relating to categorisation
-    boolean_categories = ['cat1']
+    boolean_categories = ['categoryboolean1']
 
     dom = DominantAutosomal(pedigree=make_flexible_pedigree(pedigree_path))
 

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -79,7 +79,7 @@ def test_dominant_autosomal_fails_on_depth(pedigree_path):
     test case for autosomal dominant depth failure
     """
 
-    info_dict = {'gnomad_af': 0.0001, 'gnomad_ac': 0, 'gnomad_hom': 0, 'gene_id': 'TEST1'}
+    info_dict = {'gnomad_af': 0.0001, 'af': 0.0001, 'gnomad_ac': 0, 'gnomad_hom': 0, 'gene_id': 'TEST1'}
     dom = DominantAutosomal(pedigree=make_flexible_pedigree(pedigree_path))
 
     # passes with heterozygous
@@ -100,7 +100,7 @@ def test_dominant_autosomal_passes(pedigree_path):
     :return:
     """
 
-    info_dict = {'gnomad_af': 0.0001, 'gnomad_ac': 0, 'gnomad_hom': 0, 'cat1': True, 'gene_id': 'TEST1'}
+    info_dict = {'gnomad_af': 0.0001, 'af': 0.0001, 'gnomad_ac': 0, 'gnomad_hom': 0, 'cat1': True, 'gene_id': 'TEST1'}
 
     # attributes relating to categorisation
     boolean_categories = ['cat1']
@@ -144,11 +144,22 @@ def test_dominant_autosomal_passes(pedigree_path):
 
 
 @pytest.mark.parametrize('info', [{'gnomad_af': 0.1}, {'gnomad_hom': 2}])
-def test_dominant_autosomal_fails(info, pedigree_path):
+def test_dominant_autosomal_fails_gnomad(info, pedigree_path):
     """
-    test case for autosomal dominant
-    :param info: info dict for the variant
-    :return:
+    test case for autosomal dominant failing for high AC in gnomad
+    """
+
+    dom = DominantAutosomal(pedigree=make_flexible_pedigree(pedigree_path))
+
+    # fails due to high af
+    failing_variant = SmallVariant(info=info, het_samples={'male'}, coordinates=TEST_COORDS, transcript_consequences=[])
+    assert not dom.run(principal=failing_variant)
+
+
+@pytest.mark.parametrize('info', [{'af': 0.1}, {'gnomad_hom': 2}])
+def test_dominant_autosomal_fails_callset(info, pedigree_path):
+    """
+    test case for autosomal dominant failing due to frequency within the callset
     """
 
     dom = DominantAutosomal(pedigree=make_flexible_pedigree(pedigree_path))


### PR DESCRIPTION
# Fixes

This PR is a couple of different places we can tighten up filtering whilst remaining consistent with the models we currently have. Not saying we should accept everything here as-is, but it's how we can get at these different behaviours.

  - We have too many places where being pathogenic in ClinVar is an escape for rational filtering:
      - quality failures in variant calling
      - **really** high frequency variants
  - As a consequence we're not super robust to lower quality/higher noise callsets, as a pathogenic rating in a common variant can lead to high noise levels in the final report (see recently 2900 inclusions of the same variant)
  - Relevant: https://centrepopgen.slack.com/archives/C035QN8C0DN/p1737089610442549

## Proposed Changes

  - Remove a few of the filtering escapes, add a few additional filters.
 
1. By default, any variants which are flagged for being low depth or with a wild allelic balance in the proband are excluded from the final report. This can be overridden by providing a list of permitted flags in the config file. 
    - the two non-QC related flags we use are `['Ambiguous Cat.1 MOI', 'Affected female with heterozygous variant in XLR gene']`, so by default we would only retain variants with these labels.

2. By default, being pathogenic in Clinvar/Exomiser is no longer an escape for variants with a high frequency (1+%) in the callset. Given that our current callsets are now all in the hundreds or thousands, a flat 1% filter should be a sufficiently high threshold that we don't need this escape.
     - a config switch allow selection of the previous method which will retain ClinVar/Exomiser pathogenics no matter how common.
    
3. During MOI tests we've always used a stricter gnomAD filter for Dominant variants - under 1% in the callset to get through the Hail Stage, under 0.1% in gnomAD to get to the final report. This is now applied to the callset AC as well (this is currently escaped by being pathogenic in ClinVar)

      - outcome here is that we'll keep variants up to 1% frequency within the callset until the MOI filtering stage, then at that point we will apply a stricter 0.1% callset AC filter to Dominant variants only. 
      - this has an escape... the frequency filtering we do in Hail says "only apply this filter if there are more than 5 instances, so that we don't hard filter everything in smaller callsets (below 500 individuals, 0.001% is less than one variant, so everything could be removed). We have something similar here to say "if callset AC is below `n`, no filter, if it's above `n`, it must be sufficiently rare"

## Checklist

- [?] Related Issue created
- [x] Tests covering new change
- [x] Linting checks pass