### PR TITLE
Partial fix for variant inflation

### DIFF
--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -266,7 +266,7 @@ def annotate_splicevardb(mt: hl.MatrixTable, svdb_path: str | None):
                 svdb_location=MISSING_STRING,
                 svdb_method=MISSING_STRING,
                 svdb_doi=MISSING_STRING,
-            )
+            ),
         )
 
         # read in the codon table

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -947,7 +947,7 @@ def main(
     # repartition if required - local Hail with finite resources has struggled with some really high (~120k) partitions
     # this creates a local duplicate of the input data with far smaller partition counts, for less processing overhead
     if mt.n_partitions() > MAX_PARTITIONS:
-        get_logger().info('Shrinking partitions way down with a unshuffled repartition')
+        get_logger().info('Shrinking partitions way down with an unshuffled repartition')
         mt = mt.repartition(shuffle=False, n_partitions=number_of_cores * 10)
         if checkpoint:
             get_logger().info('Trying to write the result locally, might need more space on disk...')

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -107,6 +107,23 @@ def annotate_exomiser(mt: hl.MatrixTable, exomiser: str | None = None) -> hl.Mat
     Returns:
         The same MatrixTable but with additional annotations
     """
+    if not exomiser or (
+        'exomiser'
+        in config_retrieve(
+            ['ValidateMOI', 'ignore_categories'],
+            [],
+        )
+    ):
+        get_logger().info('No exomiser table found, skipping annotation')
+        return mt.annotate_rows(info=mt.info.annotate(categorydetailsexomiser=MISSING_STRING))
+
+    get_logger().info(f'loading exomiser variants from {exomiser}')
+    exomiser_ht = hl.read_table(exomiser)
+    return mt.annotate_rows(
+        info=mt.info.annotate(
+            categorydetailsexomiser=hl.or_else(exomiser_ht[mt.row_key].proband_details, MISSING_STRING),
+        ),
+    )
 
     get_logger().info('No exomiser table found, skipping annotation')
     return mt.annotate_rows(info=mt.info.annotate(categorydetailsexomiser=MISSING_STRING))
@@ -235,16 +252,46 @@ def annotate_splicevardb(mt: hl.MatrixTable, svdb_path: str | None):
     Returns:
         Same MT with an extra category label
     """
+    if svdb_path is None or (
+        'svdb'
+        in config_retrieve(
+            ['ValidateMOI', 'ignore_categories'],
+            [],
+        )
+    ):
+        get_logger().info('Skipping SVDB annotation')
+        return mt.annotate_rows(
+            info=mt.info.annotate(
+                categorybooleansvdb=MISSING_INT,
+                svdb_location=MISSING_STRING,
+                svdb_method=MISSING_STRING,
+                svdb_doi=MISSING_STRING,
+            )
+        )
 
-    get_logger().info('SVDB table not found, skipping annotation')
+        # read in the codon table
+    get_logger().info(f'Reading SpliceVarDB data from {svdb_path}')
+    svdb_ht = hl.read_table(svdb_path)
+
+    # annotate relevant variants with the SVDB results
+    mt = mt.annotate_rows(
+        info=mt.info.annotate(
+            svdb_classification=hl.or_else(svdb_ht[mt.row_key].classification, MISSING_STRING),
+            svdb_location=hl.or_else(svdb_ht[mt.row_key].location, MISSING_STRING),
+            svdb_method=hl.or_else(svdb_ht[mt.row_key].method, MISSING_STRING),
+            svdb_doi=hl.or_else(svdb_ht[mt.row_key].doi, MISSING_STRING),
+        ),
+    )
+
+    # annotate category if Splice-altering according to SVDB
     return mt.annotate_rows(
         info=mt.info.annotate(
-            categorydetailssvdb=MISSING_STRING,
-            svdb_classification=MISSING_STRING,
-            svdb_location=MISSING_STRING,
-            svdb_method=MISSING_STRING,
-            svdb_doi=MISSING_STRING,
-        )
+            categorybooleansvdb=hl.if_else(
+                mt.info.svdb_classification.lower().contains(SPLICE_ALTERING),
+                ONE_INT,
+                MISSING_INT,
+            ),
+        ),
     )
 
 

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -289,13 +289,7 @@ def filter_on_quality_flags(mt: hl.MatrixTable) -> hl.MatrixTable:
     """
 
     return mt.filter_rows(
-        hl.is_missing(mt.filters)
-        | (mt.filters.length() == 0)
-        | (
-            (mt.info.clinvar_talos == ONE_INT)
-            | (mt.info.categorybooleansvdb == ONE_INT)
-            | (mt.info.categorydetailsexomiser != MISSING_STRING)
-        ),
+        hl.is_missing(mt.filters) | (mt.filters.length() == 0) | (mt.info.clinvar_talos == ONE_INT),
     )
 
 
@@ -361,11 +355,7 @@ def filter_matrix_by_ac(mt: hl.MatrixTable, ac_threshold: float = 0.01) -> hl.Ma
     min_callset_ac = 5
     return mt.filter_rows(
         ((min_callset_ac >= mt.info.AC[0]) | (ac_threshold > mt.info.AC[0] / mt.info.AN))
-        | (
-            (mt.info.clinvar_talos == ONE_INT)
-            | (mt.info.categorybooleansvdb == ONE_INT)
-            | (mt.info.categorydetailsexomiser != MISSING_STRING)
-        ),
+        | (mt.info.clinvar_talos == ONE_INT),
     )
 
 

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -239,7 +239,7 @@ def annotate_splicevardb(mt: hl.MatrixTable, svdb_path: str | None):
     get_logger().info('SVDB table not found, skipping annotation')
     return mt.annotate_rows(
         info=mt.info.annotate(
-            categorydetailsSVDB=MISSING_STRING,
+            categorydetailssvdb=MISSING_STRING,
             svdb_classification=MISSING_STRING,
             svdb_location=MISSING_STRING,
             svdb_method=MISSING_STRING,

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -108,17 +108,8 @@ def annotate_exomiser(mt: hl.MatrixTable, exomiser: str | None = None) -> hl.Mat
         The same MatrixTable but with additional annotations
     """
 
-    if not exomiser:
-        get_logger().info('No exomiser table found, skipping annotation')
-        return mt.annotate_rows(info=mt.info.annotate(categorydetailsexomiser=MISSING_STRING))
-
-    get_logger().info(f'loading exomiser variants from {exomiser}')
-    exomiser_ht = hl.read_table(exomiser)
-    return mt.annotate_rows(
-        info=mt.info.annotate(
-            categorydetailsexomiser=hl.or_else(exomiser_ht[mt.row_key].proband_details, MISSING_STRING),
-        ),
-    )
+    get_logger().info('No exomiser table found, skipping annotation')
+    return mt.annotate_rows(info=mt.info.annotate(categorydetailsexomiser=MISSING_STRING))
 
 
 def annotate_codon_clinvar(mt: hl.MatrixTable, pm5_path: str | None):
@@ -245,33 +236,15 @@ def annotate_splicevardb(mt: hl.MatrixTable, svdb_path: str | None):
         Same MT with an extra category label
     """
 
-    if svdb_path is None:
-        get_logger().info('SVDB table not found, skipping annotation')
-        return mt.annotate_rows(info=mt.info.annotate(categorydetailsSVDB=MISSING_STRING))
-
-    # read in the codon table
-    get_logger().info(f'Reading SpliceVarDB data from {svdb_path}')
-    svdb_ht = hl.read_table(svdb_path)
-
-    # annotate relevant variants with the SVDB results
-    mt = mt.annotate_rows(
-        info=mt.info.annotate(
-            svdb_classification=hl.or_else(svdb_ht[mt.row_key].classification, MISSING_STRING),
-            svdb_location=hl.or_else(svdb_ht[mt.row_key].location, MISSING_STRING),
-            svdb_method=hl.or_else(svdb_ht[mt.row_key].method, MISSING_STRING),
-            svdb_doi=hl.or_else(svdb_ht[mt.row_key].doi, MISSING_STRING),
-        ),
-    )
-
-    # annotate category if Splice-altering according to SVDB
+    get_logger().info('SVDB table not found, skipping annotation')
     return mt.annotate_rows(
         info=mt.info.annotate(
-            categorybooleansvdb=hl.if_else(
-                mt.info.svdb_classification.lower().contains(SPLICE_ALTERING),
-                ONE_INT,
-                MISSING_INT,
-            ),
-        ),
+            categorydetailsSVDB=MISSING_STRING,
+            svdb_classification=MISSING_STRING,
+            svdb_location=MISSING_STRING,
+            svdb_method=MISSING_STRING,
+            svdb_doi=MISSING_STRING,
+        )
     )
 
 

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -57,6 +57,12 @@ max_parent_ab = 0.05
 minimum_depth = 10
 spliceai = 0.5
 
+# Hail's gVCF combiner is a cheaper approach to joint-calling, but drops some data regarding call quality
+# one specific issue is that the 0/0 GT for Wild-types is established, but the Allele Depths are missing
+# This has specific implications for our de novo filtering process, which relies heavily on PL and AD fields
+# If this attribute is True, we replace all missing ADs with [DP, 0] if DP is populated, else [30, 0]
+update_wt_ad = true
+
 [RunHailFiltering.cores]
 small_variants = 8
 

--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -183,7 +183,6 @@ class VariantCommon(BaseModel):
         categories: set[str] = set()
         for category in self.sample_categories:
             cat_samples = self.info[category]
-            print(cat_samples, category)
             if not isinstance(cat_samples, list):
                 raise TypeError(f'Sample categories should be a list: {cat_samples}')
             if sample in cat_samples:
@@ -271,11 +270,13 @@ class SmallVariant(VariantCommon):
         """
         gets all report flags for this sample - currently only one flag
         """
-        return self.check_ab_ratio(sample) | self.check_read_depth(sample)
+        return self.check_ab_ratio(sample) | self.check_read_depth_strict(sample)
 
     def check_read_depth(self, sample: str, threshold: int = 10, var_is_cat_1: bool = False) -> set[str]:
         """
         flag low read depth for this sample
+        this version is used to determine whether a variant should be considered for _this_ sample
+        in this situation we pass variants in clinvar, regardless of read depth
 
         Args:
             sample (str): sample ID matching VCF
@@ -287,6 +288,19 @@ class SmallVariant(VariantCommon):
         """
         if var_is_cat_1:
             return set()
+        return self.check_read_depth_strict(sample, threshold)
+
+    def check_read_depth_strict(self, sample: str, threshold: int = 10) -> set[str]:
+        """
+        flag low read depth for this sample - doesn't care if it's in ClinVar
+
+        Args:
+            sample (str): sample ID matching VCF
+            threshold (int): cut-off for flagging as a failure
+
+        Returns:
+            return a flag if this sample has low read depth
+        """
         if self.depths[sample] < threshold:
             return {'Low Read Depth'}
         return set()
@@ -355,6 +369,8 @@ class ReportVariant(BaseModel):
     support_vars: set[str] = Field(default_factory=set)
     # log whether there was an increase in ClinVar star rating since the last run
     clinvar_increase: bool = Field(default=False)
+    # exomiser results - I'd like to store this in a cleaner way in future
+    exomiser_results: list[str] = Field(default_factory=list)
 
     def __eq__(self, other):
         """

--- a/test/test_hail_categories.py
+++ b/test/test_hail_categories.py
@@ -157,23 +157,18 @@ def test_green_from_panelapp():
 
 
 @pytest.mark.parametrize(
-    'exomes,genomes,clinvar,svdb,exomiser,length',
+    'exomes,genomes,clinvar,length',
     [
-        [0, 0, 0, 0, 'missing', 1],
-        [1.0, 0, 0, 0, 'missing', 0],
-        [1.0, 0, 0, 0, 'present', 1],
-        [1.0, 0, 0, 1, 'missing', 1],
-        [1.0, 0, 1, 0, 'missing', 1],
-        [0.0001, 0.0001, 0, 0, 'missing', 1],
-        [0.0001, 0.0001, 1, 0, 'missing', 1],
+        [0, 0, 0, 1],
+        [1.0, 0, 0, 0],
+        [0.0001, 0.0001, 0, 1],
+        [0.0001, 0.0001, 1, 1],
     ],
 )
 def test_filter_rows_for_rare(
     exomes: float,
     genomes: float,
     clinvar: int,
-    svdb: int,
-    exomiser: str,
     length: int,
     make_a_mt,
 ):
@@ -183,11 +178,7 @@ def test_filter_rows_for_rare(
     anno_matrix = make_a_mt.annotate_rows(
         gnomad_genomes=hl.Struct(AF=genomes),
         gnomad_exomes=hl.Struct(AF=exomes),
-        info=make_a_mt.info.annotate(
-            clinvar_talos=clinvar,
-            categorybooleansvdb=svdb,
-            categorydetailsexomiser=exomiser,
-        ),
+        info=make_a_mt.info.annotate(clinvar_talos=clinvar),
     )
     matrix = filter_to_population_rare(anno_matrix)
     assert matrix.count_rows() == length

--- a/test/test_hail_filters.py
+++ b/test/test_hail_filters.py
@@ -9,25 +9,21 @@ from talos.RunHailFiltering import filter_matrix_by_ac, filter_on_quality_flags,
 
 
 @pytest.mark.parametrize(  # needs clinvar
-    'ac,an,clinvar,svdb,exomiser,threshold,rows',
+    'ac,an,clinvar,threshold,rows',
     [
-        ([1], 1, 0, 0, 'missing', 0.01, 1),
-        ([6], 1, 0, 0, 'missing', 0.01, 0),
-        ([6], 1, 0, 1, 'missing', 0.01, 1),
-        ([6], 1, 0, 0, 'present', 0.01, 1),
-        ([6], 1, 1, 0, 'missing', 0.01, 1),
-        ([6], 70, 0, 0, 'missing', 0.1, 1),
-        ([50], 999999, 0, 0, 'missing', 0.01, 1),
-        ([50], 50, 0, 0, 'missing', 0.01, 0),
-        ([50], 50, 1, 0, 'missing', 0.01, 1),
+        ([1], 1, 0, 0.01, 1),
+        ([6], 1, 0, 0.01, 0),
+        ([6], 1, 1, 0.01, 1),
+        ([6], 70, 0, 0.1, 1),
+        ([50], 999999, 0, 0.01, 1),
+        ([50], 50, 0, 0.01, 0),
+        ([50], 50, 1, 0.01, 1),
     ],
 )
 def test_ac_filter_no_filt(
     ac: int,
     an: int,
     clinvar: int,
-    svdb: str,
-    exomiser: str,
     threshold: float,
     rows: int,
     make_a_mt: hl.MatrixTable,
@@ -41,8 +37,6 @@ def test_ac_filter_no_filt(
             clinvar_talos=clinvar,
             AC=ac,
             AN=an,
-            categorybooleansvdb=svdb,
-            categorydetailsexomiser=exomiser,
         ),
     )
 
@@ -50,22 +44,18 @@ def test_ac_filter_no_filt(
 
 
 @pytest.mark.parametrize(
-    'filters,clinvar,svdb,exomiser,length',
+    'filters,clinvar,length',
     [
-        (hl.empty_set(hl.tstr), 0, 0, 'missing', 1),
-        (hl.literal({'fail'}), 0, 0, 'missing', 0),
-        (hl.literal({'fail'}), 0, 1, 'missing', 1),
-        (hl.literal({'fail'}), 0, 0, 'present', 1),
-        (hl.literal({'fail'}), 1, 0, 'missing', 1),
-        (hl.literal({'VQSR'}), 0, 0, 'missing', 0),
-        (hl.literal({'VQSR'}), 1, 0, 'missing', 1),
+        (hl.empty_set(hl.tstr), 0, 1),
+        (hl.literal({'fail'}), 0, 0),
+        (hl.literal({'fail'}), 1, 1),
+        (hl.literal({'VQSR'}), 0, 0),
+        (hl.literal({'VQSR'}), 1, 1),
     ],
 )
 def test_filter_on_quality_flags(
     filters: hl.set,
     clinvar: int,
-    svdb: str,
-    exomiser: str,
     length: int,
     make_a_mt: hl.MatrixTable,
 ):
@@ -76,11 +66,7 @@ def test_filter_on_quality_flags(
     anno_matrix = make_a_mt.key_rows_by('locus')
     anno_matrix = anno_matrix.annotate_rows(
         filters=filters,
-        info=anno_matrix.info.annotate(
-            clinvar_talos=clinvar,
-            categorybooleansvdb=svdb,
-            categorydetailsexomiser=exomiser,
-        ),
+        info=anno_matrix.info.annotate(clinvar_talos=clinvar),
     )
     assert filter_on_quality_flags(anno_matrix).count_rows() == length
 


### PR DESCRIPTION
This is the current state of Talos as-run in the latest validation benchmarks. This PR is being made to separate the current logic from the proposed frequency filters. Adding both in the same PR will get messy.

# Fixes

  - The addition of Exomiser and SpliceVarDB categories were done quite heavy-handedly - they were given equal weighting to ClinVar (i.e. a variant was able to escape a range of quality/frequency filters on the basis of SVDB or Exomiser annotations). This has been revoked ⛔ They are still given the impact of a full category, but are not given the escalated priority of ClinVar
  - The application of data from Clinvar, Exomiser, and SVDB during the Hail stage can be overwhelming for the VM being used. This improves performance by annotating with ClinVar, applying the coarse filters where ClinVar can be used to evade variant removal, saving the MT using a checkpoint, and only then applying the Exomiser and SVDB data as annotations into the smaller remaining MatrixTable. Additionally if svdb or exomiser are added in config as categories we're not interested in, their results are never annotated into the main MT. 
  - Internally our use of the Combiner for cost efficiencies means that we're missing true AD data for WT calls. This has massive implications for the de novo tests. To cover for this, if a variant is WT but has no AD, we populate this with [DP, 0], which tricks the de novo quality filters. This will lead to an inflation of false positive de novo calls, but on the basis that we're trying to present variants for manual review, platforms like Seqr make it easy to review read-level data, where variants which are unlikely to be true de novos can be weeded out.
 