### PR TITLE
Fix partner variant bug

### DIFF
--- a/src/talos/models.py
+++ b/src/talos/models.py
@@ -155,7 +155,7 @@ class VariantCommon(BaseModel):
         if not allow_support:
             categories_applied -= self.support_categories
 
-        return bool(len(categories_applied) > 0)
+        return len(categories_applied) > 0
 
     def check_ab_ratio(self, *args, **kwargs) -> set[str]:  # noqa: ARG002, ANN002, ANN003
         """

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -101,12 +101,12 @@ def check_for_second_hit(
     if sample not in comp_hets:
         return []
 
-    partners = comp_hets[sample].get(first_variant, [])
-
     # thin out the possible partners by alt depth
-    partners = [partner for partner in partners if not partner.check_minimum_alt_depth(sample, min_alt_depth)]
-
-    return partners
+    return [
+        var
+        for var in comp_hets[sample].get(first_variant, [])
+        if not var.check_minimum_alt_depth(sample, min_alt_depth)
+    ]
 
 
 class MOIRunner:
@@ -488,7 +488,7 @@ class RecessiveAutosomalCH(BaseMoi):
                         [
                             principal.sample_category_check(sample_id, allow_support=False),
                             partner_variant.sample_category_check(sample_id, allow_support=False),
-                        ]
+                        ],
                     )
                 ):
                     continue
@@ -1020,6 +1020,7 @@ class XRecessiveFemaleCH(BaseMoi):
                 first_variant=principal.coordinates.string_format,
                 comp_hets=comp_het,
                 sample=sample_id,
+                min_alt_depth=self.minimum_alt_depth,
             ):
                 # allow for de novo check - also screen out high-AF partners
                 if too_common_in_population(
@@ -1029,7 +1030,7 @@ class XRecessiveFemaleCH(BaseMoi):
                     [
                         principal.sample_category_check(sample_id, allow_support=False),
                         partner.sample_category_check(sample_id, allow_support=False),
-                    ]
+                    ],
                 ):
                     continue
 

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -444,9 +444,6 @@ class RecessiveAutosomalCH(BaseMoi):
             list[ReportVariant]: data object if RecessiveAutosomal fits
         """
 
-        if principal.coordinates.pos == 71652747:
-            print('waiting')
-
         if comp_het is None:
             comp_het = {}
 
@@ -461,7 +458,6 @@ class RecessiveAutosomalCH(BaseMoi):
 
         # if hets are present, try and find support
         for sample_id in principal.het_samples:
-            print(sample_id)
             # skip primary analysis for unaffected members
             # this sample must be categorised - check Cat 4 contents
             if (

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -70,7 +70,6 @@ def check_for_second_hit(
     first_variant: str,
     comp_hets: CompHetDict,
     sample: str,
-    require_non_support: bool = False,
     min_alt_depth: int = 5,
 ) -> list[VARIANT_MODELS]:
     """
@@ -92,7 +91,7 @@ def check_for_second_hit(
         first_variant (str): string representation of variant1
         comp_hets (dict[str, Variant]): lookup for compound hets
         sample (str): sample ID
-        require_non_support (bool): if true, don't return Support only
+        min_alt_depth (int): skip over partners without the minimum alt read support
 
     Returns:
         a list of variants which are potential partners
@@ -107,10 +106,6 @@ def check_for_second_hit(
     # thin out the possible partners by alt depth
     partners = [partner for partner in partners if not partner.check_minimum_alt_depth(sample, min_alt_depth)]
 
-    if require_non_support:
-        return [
-            partner for partner in partners if partner.sample_category_check(sample, allow_support=require_non_support)
-        ]
     return partners
 
 
@@ -481,16 +476,24 @@ class RecessiveAutosomalCH(BaseMoi):
                 first_variant=principal.coordinates.string_format,
                 comp_hets=comp_het,
                 sample=sample_id,
-                require_non_support=principal.sample_category_check(sample_id, allow_support=False),
                 min_alt_depth=self.minimum_alt_depth,
             ):
-                if partner_variant.check_read_depth(
-                    sample_id,
-                    self.minimum_depth,
-                    partner_variant.info.get('categoryboolean1'),
-                ) or too_common_in_population(
-                    partner_variant.info,
-                    self.freq_tests[partner_variant.__class__.__name__],
+                if (
+                    partner_variant.check_read_depth(
+                        sample_id,
+                        self.minimum_depth,
+                        partner_variant.info.get('categoryboolean1'),
+                    )
+                    or too_common_in_population(
+                        partner_variant.info,
+                        self.freq_tests[partner_variant.__class__.__name__],
+                    )
+                    or not any(
+                        [
+                            principal.sample_category_check(sample_id, allow_support=False),
+                            partner_variant.sample_category_check(sample_id, allow_support=False),
+                        ]
+                    )
                 ):
                     continue
 
@@ -1021,12 +1024,16 @@ class XRecessiveFemaleCH(BaseMoi):
                 first_variant=principal.coordinates.string_format,
                 comp_hets=comp_het,
                 sample=sample_id,
-                require_non_support=principal.sample_category_check(sample_id, allow_support=False),
             ):
                 # allow for de novo check - also screen out high-AF partners
                 if too_common_in_population(
                     partner.info,
                     self.freq_tests[partner.__class__.__name__],
+                ) or not any(
+                    [
+                        principal.sample_category_check(sample_id, allow_support=False),
+                        partner.sample_category_check(sample_id, allow_support=False),
+                    ]
                 ):
                     continue
 


### PR DESCRIPTION
# Fixes

  - A bug in the support category checking prevented variants reaching the report if... they had other categories assigned, but the partner variant didn't?
  - A weird one for sure, it meant that if a Cat6 only and a Cat1 only were in the VCF, and Cat6 was a support, the only variant which would reach the report was the 6 🙃 

## Proposed Changes

  -
  -
  -

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
