### PR TITLE
Add custom Gene-MOI data

### DIFF
--- a/nextflow/inputs/config.toml
+++ b/nextflow/inputs/config.toml
@@ -19,6 +19,25 @@ within_x_months = 3
 forbidden_genes = []
 forced_panels = [ 144,]
 
+[GeneratePanelData.manual_overrides]
+# this section permits the manual addition of genes to the panel data
+# each gene here will be folded into the panelapp data after standard API queries have taken place
+# if the gene was already identified for this analysis, the MOI provided here will take precedent
+# if the gene here was not identified through panelapp, a new entity will be added, and the panel ID
+# associated with it will be the number zero (panel IDs must all be numeric, 0 is not in use)
+[[GeneratePanelData.manual_overrides.genes]]
+# this field is mandatory - the ENSG ID of the gene
+ensg = 'ENSG0000012345'
+
+# this field should be supplied, if omitted will default to Mono_And_Biallelic
+moi = 'Biallelic'
+
+# optional - if ommitted the gene symbol will be looked up in the Ensembl data
+symbol = 'AGENE'
+
+# optional
+chrom = '1'
+
 [FindGeneSymbolMap]
 chunk_size = 800
 

--- a/src/talos/HPOFlagging.py
+++ b/src/talos/HPOFlagging.py
@@ -26,24 +26,9 @@ from semsimian import Semsimian
 from talos.config import config_retrieve
 from talos.models import ParticipantResults, ResultData
 from talos.static_values import get_granular_date
-from talos.utils import phenotype_label_history, read_json_from_path
+from talos.utils import phenotype_label_history, read_json_from_path, parse_mane_json_to_dict
 
 _SEMSIM_CLIENT: Semsimian | None = None
-
-
-def read_and_filter_mane_json(mane_json: str) -> dict:
-    """
-    Read the MANE JSON and filter it to the relevant fields
-    Args:
-        mane_json ():
-
-    Returns:
-        a dictionary of {Symbol: ID}
-    """
-
-    json_dict = read_json_from_path(mane_json)
-
-    return {entry['symbol']: entry['ensg'] for entry in json_dict.values()}
 
 
 def get_sem_client(phenio_db: str | None = None) -> Semsimian:
@@ -270,7 +255,7 @@ def main(
         phenout (str): optional, path to phenotype filtered outputs
     """
 
-    gene_map = read_and_filter_mane_json(mane_json)
+    gene_map = parse_mane_json_to_dict(mane_json)
 
     # read the results JSON into an object
     results = read_json_from_path(result_file, return_model=ResultData)

--- a/src/talos/QueryPanelapp.py
+++ b/src/talos/QueryPanelapp.py
@@ -12,7 +12,14 @@ from dateutil.utils import today
 
 from talos.config import config_retrieve
 from talos.models import PanelApp, PanelDetail, PanelShort, PhenotypeMatchedPanels
-from talos.utils import ORDERED_MOIS, get_json_response, get_logger, get_simple_moi, read_json_from_path
+from talos.utils import (
+    ORDERED_MOIS,
+    get_json_response,
+    get_logger,
+    get_simple_moi,
+    read_json_from_path,
+    parse_mane_json_to_dict,
+)
 
 
 # global variables for PanelApp interaction
@@ -33,6 +40,8 @@ GENE_CONSTANT = 'gene'
 TODAY = today()
 REALLY_OLD = parse('1970-01-01')
 ACTIVITY_CONTENT = {'green list (high evidence)', 'expert review green'}
+DEFAULT_MOI_FOR_MANUAL_GENES = 'Mono_And_Biallelic'
+DEFAULT_PANEL_ID = 0
 
 
 def request_panel_data(url: str) -> tuple[str, str, list]:
@@ -151,6 +160,7 @@ def get_panel(
         ensg = None
         chrom = None
 
+        # TODO stop picking up ENSG from here
         # for some reason the build is capitalised oddly in panelapp
         # at least one entry doesn't have an ENSG annotation
         for build, content in gene['gene_data']['ensembl_genes'].items():
@@ -219,28 +229,60 @@ def get_best_moi(gene_dict: dict):
             content.moi = sorted(simplified_mois, key=lambda x: ORDERED_MOIS.index(x))[0]
 
 
-def update_moi_from_config(gene_dict: PanelApp, update_dict: dict[str, str]) -> PanelApp:
+def update_moi_from_config(
+    gene_dict: PanelApp,
+    add_genes: list[dict[str, str]],
+    gene_json: str | None = None,
+) -> PanelApp:
     """
+    Add additional genes from config
     Update the MOI for a gene or genes based on a dictionary of gene: moi
 
     Args:
         gene_dict (PanelApp): the gene data to update
-        update_dict (dict): the gene: moi dictionary
+        add_genes (list[dict]): entities to add
+        gene_json (str | None): path to the symbol: ensg dictionary in JSON form
     """
 
-    get_logger().info(f'Overriding MOI for specific genes: {", ".join(update_dict.keys())}')
-    for gene, moi in update_dict.items():
+    get_logger().info(f'Overriding MOI for specific genes: {add_genes}')
+
+    # read the MANE file into a dictionary
+    mane_lookup = parse_mane_json_to_dict(gene_json) if gene_json else {}
+
+    for gene_data in add_genes:
+        # this field is mandatory
+        ensg = gene_data['ensg']
+
+        # not essential, but if we have a symbol lookup, use it
+        # if it wasn't provided, use the lookup, if it's not in the lookup, use ENSG
+        symbol = gene_data.get('symbol', mane_lookup.get(ensg, ensg))
+
+        # this field is optional
+        moi = gene_data.get('moi', DEFAULT_MOI_FOR_MANUAL_GENES)
+
         if moi not in ORDERED_MOIS:
-            raise ValueError(f'{moi} for {gene} is not a valid MOI, choose from {", ".join(ORDERED_MOIS)}')
-        get_logger().info(f'Overriding {gene} MOI to {moi}')
-        if gene not in gene_dict.genes:
-            raise ValueError(f'{gene} was not sourced from PanelApp')
-        current_moi = gene_dict.genes[gene].moi
-        if current_moi == moi:
-            get_logger().info(f'{gene} MOI was already {moi}, no change made')
+            raise ValueError(f'{moi} for {ensg} is not a valid MOI, choose from {", ".join(ORDERED_MOIS)}')
+
+        # if this is a gene we already know about, try and update the MOI
+        # and add the custom panel ID to associated panels
+        if ensg in gene_dict.genes:
+            current_moi = gene_dict.genes[ensg].moi
+            if current_moi == moi:
+                get_logger().info(f'{ensg} MOI was already {moi}, no change made')
+            else:
+                get_logger().info(f'{ensg} MOI was updated from {current_moi} to {moi}')
+                gene_dict.genes[ensg].moi = moi
+            gene_dict.genes[ensg].panels.add(DEFAULT_PANEL_ID)
+
         else:
-            get_logger().info(f'{gene} MOI was updated from {current_moi} to {moi}')
-            gene_dict.genes[gene].moi = moi
+            # if this is a new gene, add it to the dictionary
+            gene_dict.genes[ensg] = PanelDetail(
+                symbol=symbol,
+                all_moi={moi},
+                moi=moi,
+                panels={DEFAULT_PANEL_ID},
+                chrom=gene_data.get('chrom', 'chrUnknown'),
+            )
     return gene_dict
 
 
@@ -248,11 +290,12 @@ def cli_main():
     parser = ArgumentParser()
     parser.add_argument('--input', help='JSON of per-participant panels', default=None)
     parser.add_argument('--output', required=True, help='destination for results')
+    parser.add_argument('--gene_json', help='path to gene symbol JSON', default=None)
     args = parser.parse_args()
-    main(panels=args.input, out_path=args.output)
+    main(panels=args.input, out_path=args.output, gene_json_path=args.gene_json)
 
 
-def main(panels: str | None, out_path: str):
+def main(panels: str | None, out_path: str, gene_json_path: str | None = None):
     """
     Queries PanelApp for all the gene panels to use in the current analysis
     queries panelapp for each panel in turn, aggregating results
@@ -260,6 +303,7 @@ def main(panels: str | None, out_path: str):
     Args:
         panels (): file containing per-participant panels
         out_path (): where to write the results out to
+        gene_json_path (): path to gene symbol JSON, used to obtain a lookup of symbol to ENSG ID
     """
 
     get_logger().info('Starting PanelApp Query Stage')
@@ -301,15 +345,9 @@ def main(panels: str | None, out_path: str):
     # now get the best MOI, and update the entities in place
     get_best_moi(gene_dict.genes)
 
-    # optional block here - override the naturally discovered MOI for a gene or genes, based on config
-    # this config entry should look like a dictionary of gene: moi
-    # ruff: noqa: ERA001
-    # ['GeneratePanelData.forced_moi']
-    # ENSG1234 = 'MOI'
-    # ENSG5678 = 'OTHER_MOI'
-    if moi_overrides := config_retrieve(key=['GeneratePanelData', 'forced_moi'], default=None):
-        assert isinstance(moi_overrides, dict), 'MOI overrides must be a dictionary of {gene: moi,}'
-        gene_dict = update_moi_from_config(gene_dict, moi_overrides)
+    # try and pull from config, default to an empty list
+    if gene_data := config_retrieve(['GeneratePanelData', 'manual_overrides', 'genes'], []):
+        gene_dict = update_moi_from_config(gene_dict, gene_data, gene_json_path)
 
     # write the output to long term storage
     with open(out_path, 'w') as out_file:

--- a/src/talos/QueryPanelapp.py
+++ b/src/talos/QueryPanelapp.py
@@ -219,7 +219,7 @@ def get_best_moi(gene_dict: dict):
             content.moi = sorted(simplified_mois, key=lambda x: ORDERED_MOIS.index(x))[0]
 
 
-def update_moi_from_config(gene_dict: PanelApp, update_dict: dict[str, str]) -> dict:
+def update_moi_from_config(gene_dict: PanelApp, update_dict: dict[str, str]) -> PanelApp:
     """
     Update the MOI for a gene or genes based on a dictionary of gene: moi
 
@@ -303,6 +303,7 @@ def main(panels: str | None, out_path: str):
 
     # optional block here - override the naturally discovered MOI for a gene or genes, based on config
     # this config entry should look like a dictionary of gene: moi
+    # ruff: noqa: ERA001
     # ['GeneratePanelData.forced_moi']
     # ENSG1234 = 'MOI'
     # ENSG5678 = 'OTHER_MOI'

--- a/src/talos/RunHailFilteringSv.py
+++ b/src/talos/RunHailFilteringSv.py
@@ -45,6 +45,14 @@ def rearrange_annotations(mt: hl.MatrixTable, gene_mapping: hl.dict) -> hl.Matri
         same MT, with shifted annotations
     """
 
+    # accept, but don't force, this GATK-SV field
+    if 'ALGORITHMS' not in mt.info:
+        mt = mt.annotate_rows(
+            info=mt.info.annotate(
+                algorithms=['gCNV'],
+            ),
+        )
+
     mt = mt.annotate_rows(
         info=hl.struct(
             AC=mt.info.AC,

--- a/src/talos/ValidateMOI.py
+++ b/src/talos/ValidateMOI.py
@@ -201,6 +201,10 @@ def clean_and_filter(
 
     cohort_panels = set(config_retrieve(['GeneratePanelData', 'forced_panels'], []))
 
+    # add the custom gene panel ID as a forced panel
+    # any gene added manually, either to override MOI, or to add the gene completely, will be applied to every family
+    cohort_panels.add(0)
+
     panel_meta: dict[int, str] = {content.id: content.name for content in panelapp_data.metadata}
 
     gene_details: dict[str, set[int]] = {}

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -16,15 +16,30 @@ forced_panels = [1, 2, 3]
 # we treat the gene as new. New/Recent genes are highlighted in the report with a Star next to the symbol
 within_x_months = 6
 
+[GeneratePanelData.manual_overrides]
+# this section permits the manual addition of genes to the panel data
+# each gene here will be folded into the panelapp data after standard API queries have taken place
+# if the gene was already identified for this analysis, the MOI provided here will take precedent
+# if the gene here was not identified through panelapp, a new entity will be added, and the panel ID
+# associated with it will be the number zero (panel IDs must all be numeric, 0 is not in use)
+[[GeneratePanelData.manual_overrides.genes]]
+# this field is mandatory - the ENSG ID of the gene
+ensg = 'ENSG0000012345'
+
+# this field should be supplied, if omitted will default to Mono_And_Biallelic
+moi = 'Biallelic'
+
+# optional - if ommitted the gene symbol will be looked up in the Ensembl data
+symbol = 'AGENE'
+
+# optional
+chrom = '1'
+
 [GeneratePanelData.forced_moi]
 # choose gene IDs to overrule the PanelApp default MOI
 # must be selected from 'Mono_And_Biallelic', 'Monoallelic', 'Hemi_Mono_In_Female', 'Hemi_Bi_In_Female', 'Biallelic'
 # e.g.
 # ENSG1234 = 'Biallelic'
-
-[FindGeneSymbolMap]
-# much higher than this and we get into throttling issues
-chunk_size = 800
 
 [ValidateMOI]
 # thresholds for different filters during the MOI checks
@@ -121,3 +136,4 @@ semantic_match = true
 
 # min similarity score when doing a semsimian termset similarity test
 min_similarity = 14.0
+

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -1,6 +1,6 @@
 [GeneratePanelData]
 # the panelapp instance to use
-panelapp = 'https://panelapp-aus.org//api/v1/panels'
+panelapp = 'https://panelapp-aus.org/api/v1/panels'
 # panel ID in that panelapp instance to use as a base, by default this is the 'Mendeliome'
 default_panel = 137
 # these genes are removed from the base panel, but will be included if they occur in a phenotype-matched panel
@@ -34,12 +34,6 @@ symbol = 'AGENE'
 
 # optional
 chrom = '1'
-
-[GeneratePanelData.forced_moi]
-# choose gene IDs to overrule the PanelApp default MOI
-# must be selected from 'Mono_And_Biallelic', 'Monoallelic', 'Hemi_Mono_In_Female', 'Hemi_Bi_In_Female', 'Biallelic'
-# e.g.
-# ENSG1234 = 'Biallelic'
 
 [ValidateMOI]
 # thresholds for different filters during the MOI checks
@@ -136,4 +130,3 @@ semantic_match = true
 
 # min similarity score when doing a semsimian termset similarity test
 min_similarity = 14.0
-

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -16,6 +16,12 @@ forced_panels = [1, 2, 3]
 # we treat the gene as new. New/Recent genes are highlighted in the report with a Star next to the symbol
 within_x_months = 6
 
+[GeneratePanelData.forced_moi]
+# choose gene IDs to overrule the PanelApp default MOI
+# must be selected from 'Mono_And_Biallelic', 'Monoallelic', 'Hemi_Mono_In_Female', 'Hemi_Bi_In_Female', 'Biallelic'
+# e.g.
+# ENSG1234 = 'Biallelic'
+
 [FindGeneSymbolMap]
 # much higher than this and we get into throttling issues
 chunk_size = 800

--- a/src/talos/templates/variant_table_row.html.jinja
+++ b/src/talos/templates/variant_table_row.html.jinja
@@ -39,7 +39,7 @@
     <td>
         {# Gene symbol #}
         {% for gene in variant.genes %}
-        <a href="https://panelapp-aus.org//panels/entities/{{gene[1]}}" target="_blank">{{gene[1]}}</a>
+        <a href="https://panelapp-aus.org/panels/entities/{{gene[1]}}" target="_blank">{{gene[1]}}</a>
         {% endfor %}
         {% if variant.new_in_base_panel %}
         <i class="bi bi-star-fill text-warning" data-bs-toggle="tooltip" data-bs-placement="top"

--- a/src/talos/utils.py
+++ b/src/talos/utils.py
@@ -82,6 +82,21 @@ DOI_URL = 'https://doi.org/'
 PHASE_BROKEN: bool = False
 
 
+def parse_mane_json_to_dict(mane_json: str) -> dict:
+    """
+    Read the MANE JSON and filter it to the relevant fields
+    Args:
+        mane_json ():
+
+    Returns:
+        a dictionary of {Symbol: ID}
+    """
+
+    json_dict = read_json_from_path(mane_json)
+
+    return {entry['symbol']: entry['ensg'] for entry in json_dict.values()}
+
+
 def get_random_string(length: int = 6) -> str:
     """
     get a random string of a pre-determined leng`th


### PR DESCRIPTION
# Fixes

  - We don't have a way to overrule PanelApp MOI (e.g. to use Talos in a more exploratory way, testing for new gene~disease associations)
  - We don't have a way to use a non-PanelApp gene data source

## Proposed Changes

  - After all PanelApp data has been queried as normal, checks config to see if any additional gene data should be added (example section in example_config.toml)
  - User must supply at least an ENSG ID with each manually applied gene, optionally a MOI, symbol, chromosome
  - If the gene was already detected via PanelApp, the Custom gene panel is added 
    - extra panel ID 0 associated with the gene, a marker to detect manually updated genes
    - If the PanelApp MOI was different to the manually supplied one, overwrite it. 
  - If the gene was not detected in PanelApp, add a new gene section
  - By default, the MOI for manually supplied genes is mono_and_biallelic, unless set specifically in config

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [X] Linting checks pass
