### PR TITLE
Patch nf modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ annotation) and [Echtvar](https://github.com/brentp/echtvar) (used to rapidly ap
 > setting. If you apply another tag you'll have to make the corresponding change in the nextflow config files.
 
 ```commandline
-docker buildx build --target talos_none -t talos:7.0.1 .
+docker buildx build -t talos:7.0.1 .
 ```
 
 > **_NOTE:_**  Note the tag of the dockerfile in this command is kept in sync with the package version and config

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Included here are two reference workflow implementation using NextFlow:
 
 These workflows can be executed in full using a Docker image built on the [Dockerfile](Dockerfile) at the root of this
 repository. This Docker image contains Talos and all its dependencies, plus BCFtools (used for merging and consequence
-annotation) and [Echtvar](https://github.com/brentp/echtvar) (used to rapidly apply population frequencies). 
+annotation) and [Echtvar](https://github.com/brentp/echtvar) (used to rapidly apply population frequencies).
 
-> **_NOTE:_**  Note the tag of the dockerfile in this command is kept in sync with the package version and config 
+> **_NOTE:_**  Note the tag of the dockerfile in this command is kept in sync with the package version and config
 > setting. If you apply another tag you'll have to make the corresponding change in the nextflow config files.
 
 ```commandline

--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ Included here are two reference workflow implementation using NextFlow:
 
 These workflows can be executed in full using a Docker image built on the [Dockerfile](Dockerfile) at the root of this
 repository. This Docker image contains Talos and all its dependencies, plus BCFtools (used for merging and consequence
-annotation) and [Echtvar](https://github.com/brentp/echtvar) (used to rapidly apply population frequencies).
+annotation) and [Echtvar](https://github.com/brentp/echtvar) (used to rapidly apply population frequencies). 
+
+> **_NOTE:_**  Note the tag of the dockerfile in this command is kept in sync with the package version and config 
+> setting. If you apply another tag you'll have to make the corresponding change in the nextflow config files.
+
+```commandline
+docker buildx build --target talos_none -t talos:7.0.1 .
+```
 
 > **_NOTE:_**  Note the tag of the dockerfile in this command is kept in sync with the package version and config
 > setting. If you apply another tag you'll have to make the corresponding change in the nextflow config files.

--- a/nextflow/modules/annotation/ReformatAnnotatedVcfIntoHailTable/main.nf
+++ b/nextflow/modules/annotation/ReformatAnnotatedVcfIntoHailTable/main.nf
@@ -11,9 +11,8 @@ process ReformatAnnotatedVcfIntoHailTable {
     publishDir params.cohort_output_dir, mode: 'copy'
 
     output:
-        path("${params.cohort}_annotations.ht.tar.gz")
+        path("${params.cohort}_annotations.ht.tar")
 
-    // TODO write this script...
     script:
         """
         set -ex
@@ -25,11 +24,9 @@ process ReformatAnnotatedVcfIntoHailTable {
             --output ${params.cohort}_annotations.ht \
             --mane ${mane}
 
+        tar --remove-files -cf ${params.cohort}_annotations.ht.tar ${params.cohort}_annotations.ht
+
         # cut down on work folder space
         rm -r alphamissense_38.ht
-
-        tar --no-xattrs -cf ${params.cohort}_annotations.ht.tar ${params.cohort}_annotations.ht
-
-        rm -r ${params.cohort}_annotations.ht
         """
 }

--- a/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
+++ b/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
@@ -22,8 +22,6 @@ process TransferAnnotationsToMatrixTable {
 
         # cut down on work folder space
         rm -r ${params.cohort}_annotations.ht
-
 		tar --no-xattrs --remove-files -cf ${params.cohort}.mt.tar ${params.cohort}.mt
-		rm -r ${params.cohort}.mt
         """
 }


### PR DESCRIPTION
# Fixes

  - since finishing the Talos-Prep workflow, MatrixTables are no longer compressed (there was no benefit)

## Proposed Changes

  - removes the .gz suffix from the expected output of ReformatAnnotatedVcfIntoHailTable
  - uses the tar argument --remove-files to remove the need for a compress + delete as separate commands 