### PR TITLE
Remove seqr link text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 # hail logs
 hail*.log
-inputs
 
 
 # scratch files

--- a/nextflow/inputs/echtvar_config.json
+++ b/nextflow/inputs/echtvar_config.json
@@ -1,0 +1,13 @@
+[
+    {"field": "AC_joint", "alias": "gnomad_AC_joint", "missing_value": -2147483648},
+    {"field": "AN_joint", "alias": "gnomad_AN_joint", "missing_value": -2147483648},
+    {"field": "AF_joint", "alias": "gnomad_AF_joint", "missing_value": -0, "multiplier": 2000000},
+    {"field": "AC_joint_XY", "alias": "gnomad_AC_joint_XY", "missing_value": -2147483648},
+    {"field": "AF_joint_XY", "alias": "gnomad_AF_joint_XY", "missing_value": -0, "multiplier": 2000000},
+    {"field": "AC_joint_XX", "alias": "gnomad_AC_joint_XX", "missing_value": -2147483648},
+    {"field": "AF_joint_XX", "alias": "gnomad_AF_joint_XX", "missing_value": -0, "multiplier": 2000000},
+    {"field": "fafmax_faf95_max_joint", "alias": "gnomad_faf_95_joint", "missing_value": -0, "multiplier": 2000000},
+    {"field": "nhomalt_joint", "alias": "gnomad_HomAlt_joint", "missing_value": -2147483648},
+    {"field": "genomes_filters", "alias": "gnomad_genomes_filters", "missing_string": "PASS"},
+    {"field": "exomes_filters", "alias": "gnomad_exomes_filters", "missing_string": "PASS"}
+]

--- a/src/talos/cpg_internal_scripts/MinimiseOutputForSeqr.py
+++ b/src/talos/cpg_internal_scripts/MinimiseOutputForSeqr.py
@@ -66,7 +66,7 @@ def main(input_file: str, output: str, ext_map: str | None = None, pheno_match: 
             var_data = variant.var_data
             if pheno_match and not variant.panels.matched:
                 continue
-            lil_data.results[indi_id][var_data.info['seqr_link']] = MiniVariant(
+            lil_data.results[indi_id][var_data.info['var_link']] = MiniVariant(
                 categories=variant.categories,
                 support_vars=variant.support_vars,
             )

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -119,9 +119,11 @@ exomiser = 'Variant prioritised by Exomiser'
 
 [CreateTalosHTML]
 external_labels = "path to labels file"
-seqr_lookup = "e.g. gs://cpg-COHORT-test/reanalysis/parsed_seqr.json"
-seqr_instance = "e.g. https://seqr.populationgenomics.org.au"
-seqr_project = "e.g. COHORT_project_id"
+
+[CreateTalosHTML.hyperlinks]
+lookup = "e.g. gs://cpg-COHORT-test/reanalysis/parsed_seqr.json"
+template = "e.g. https://seqr.populationgenomics.org.au/COHORT_project_id/.../{sample}"
+variant_template = "e.g. https://seqr.populationgenomics.org.au/variant/{variant}/family/{sample}"
 
 [HPOFlagging]
 # this section relates to phenotype-matching the final variant set

--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -500,7 +500,7 @@ class RecessiveAutosomalCH(BaseMoi):
                             categories=principal.category_values(sample_id),
                             reasons={self.applied_moi},
                             genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
-                            support_vars={partner.info['seqr_link']},
+                            support_vars={partner.info['var_link']},
                             flags=principal.get_sample_flags(sample_id) | partner.get_sample_flags(sample_id),
                             independent=False,
                         ),
@@ -1075,7 +1075,7 @@ class XRecessiveFemaleCH(BaseMoi):
                             reasons={self.applied_moi},
                             genotypes=self.get_family_genotypes(variant=principal, sample_id=sample_id),
                             # needs to comply with Seqr
-                            support_vars={partner.info['seqr_link']},
+                            support_vars={partner.info['var_link']},
                             flags=principal.get_sample_flags(sample_id) | partner.get_sample_flags(sample_id),
                             independent=False,
                         ),

--- a/src/talos/templates/variant_table_child_row.html.jinja
+++ b/src/talos/templates/variant_table_child_row.html.jinja
@@ -12,7 +12,7 @@
                             <dt class="col-sm-3">Variant</dt>
                             <dd class="col-sm-9">
                             {% if variant.var_type == 'SmallVariant' %}
-                                {{variant.var_data.info.seqr_link}}
+                                {{variant.var_data.info.var_link}}
                                 <dt class="col-sm-3">Filter status</dt>
                                 <dd class="col-sm-9">{{variant.var_data.info.as_filterstatus}}</dd>
 

--- a/test/test_moi_tests.py
+++ b/test/test_moi_tests.py
@@ -219,7 +219,7 @@ def test_recessive_autosomal_comp_het_male_passes(pedigree_path):
         alt_depths={'male': 25},
         depths={'male': 50},
         boolean_categories=['categoryboolean1'],
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant2 = SmallVariant(
@@ -229,7 +229,7 @@ def test_recessive_autosomal_comp_het_male_passes(pedigree_path):
         alt_depths={'male': 25},
         depths={'male': 50},
         boolean_categories=['categoryboolean1'],
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {'male': {TEST_COORDS.string_format: [passing_variant2]}}
@@ -252,7 +252,7 @@ def test_recessive_autosomal_comp_het_male_passes_with_support(pedigree_path):
         depths={'male': 50},
         boolean_categories=['categoryboolean1'],
         support_categories={'6'},
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant2 = SmallVariant(
@@ -263,7 +263,7 @@ def test_recessive_autosomal_comp_het_male_passes_with_support(pedigree_path):
         depths={'male': 50},
         boolean_categories=['categoryboolean6'],
         support_categories={'6'},
-        info={'gene_id': 'TEST1', 'categoryboolean6': True, 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categoryboolean6': True, 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {
@@ -292,7 +292,7 @@ def test_recessive_autosomal_comp_het_male_fails_both_support(pedigree_path):
         depths={'male': 50},
         boolean_categories=['categoryboolean6'],
         support_categories={'6'},
-        info={'gene_id': 'TEST1', 'categoryboolean6': True, 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categoryboolean6': True, 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant2 = SmallVariant(
@@ -303,7 +303,7 @@ def test_recessive_autosomal_comp_het_male_fails_both_support(pedigree_path):
         depths={'male': 50},
         boolean_categories=['categoryboolean6'],
         support_categories={'6'},
-        info={'gene_id': 'TEST1', 'categoryboolean6': True, 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categoryboolean6': True, 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {
@@ -330,7 +330,7 @@ def test_recessive_autosomal_comp_het_male_passes_partner_flag(pedigree_path):
         alt_depths={'male': 25},
         depths={'male': 50},
         boolean_categories=['categoryboolean1'],
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant2 = SmallVariant(
@@ -340,7 +340,7 @@ def test_recessive_autosomal_comp_het_male_passes_partner_flag(pedigree_path):
         alt_depths={'male': 25},
         depths={'male': 50},
         boolean_categories=['categoryboolean1'],
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {'male': {TEST_COORDS.string_format: [passing_variant2]}}
@@ -363,7 +363,7 @@ def test_recessive_autosomal_comp_het_female_passes(pedigree_path):
         alt_depths={'female': 50},
         depths={'female': 50},
         boolean_categories=['categoryboolean1'],
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant2 = SmallVariant(
@@ -373,7 +373,7 @@ def test_recessive_autosomal_comp_het_female_passes(pedigree_path):
         alt_depths={'female': 50},
         depths={'female': 50},
         boolean_categories=['categoryboolean1'],
-        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categoryboolean1': True, 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {'female': {TEST_COORDS.string_format: [passing_variant2]}}
@@ -626,7 +626,7 @@ def test_x_recessive_female_het_passes(pedigree_path):
         alt_depths={'female': 25},
         depths={'female': 50},
         sample_categories=['categorysample4'],
-        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant_2 = SmallVariant(
@@ -636,7 +636,7 @@ def test_x_recessive_female_het_passes(pedigree_path):
         alt_depths={'female': 50},
         depths={'female': 50},
         sample_categories=['categorysample4'],
-        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {'female': {'X-1-G-T': [passing_variant_2]}}
@@ -656,7 +656,7 @@ def test_x_recessive_female_het_passes_one_support(pedigree_path):
         depths={'female': 50},
         sample_categories=['categorysample4'],
         support_categories={'4'},
-        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant_2 = SmallVariant(
@@ -667,7 +667,7 @@ def test_x_recessive_female_het_passes_one_support(pedigree_path):
         depths={'female': 50},
         sample_categories=['categorysample4'],
         support_categories=set(),
-        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {
@@ -693,7 +693,7 @@ def test_x_recessive_female_het_fails_both_support(pedigree_path):
         depths={'female': 50},
         sample_categories=['categorysample4'],
         support_categories={'4'},
-        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'seqr_link': 'passing1'},
+        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'var_link': 'passing1'},
         transcript_consequences=[],
     )
     passing_variant_2 = SmallVariant(
@@ -704,7 +704,7 @@ def test_x_recessive_female_het_fails_both_support(pedigree_path):
         depths={'female': 50},
         sample_categories=['categorysample4'],
         support_categories={'4'},
-        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'seqr_link': 'passing2'},
+        info={'gene_id': 'TEST1', 'categorysample4': ['female'], 'var_link': 'passing2'},
         transcript_consequences=[],
     )
     comp_hets = {


### PR DESCRIPTION
# Fixes

  - There were still a few instances of 'seqr_link' hanging around in the codebase, causing errors
  - The example echtvar file was absent (excluded due to a .gitignore rule) - this caused a Docker build failure
