### PR TITLE
Pull all isoforms, filter to MANE only

### DIFF
--- a/nextflow/annotation.config
+++ b/nextflow/annotation.config
@@ -26,8 +26,8 @@ params.cohort_output_dir = "nextflow/${params.cohort}_outputs"
 params.generic_output_dir = "nextflow/outputs"
 
 // Not storing a copy of the AM file, collecting it from Zenodo at runtime
-params.alphamissense_url = "https://zenodo.org/records/8208688/files/AlphaMissense_hg38.tsv.gz"
-params.alphamissense_output = "${params.generic_output_dir}/alphamissense_38.ht.tar.gz"
+params.alphamissense_url = "https://zenodo.org/records/8208688/files/AlphaMissense_isoforms_hg38.tsv.gz"
+params.alphamissense_output = "${params.generic_output_dir}/alphamissense_isoforms_38.ht.tar"
 
 // Docker image - built from Dockerfile in the root directory
 // "docker build -t talos:7.0.3 ."

--- a/nextflow/modules/annotation/ParseAlphaMissenseIntoHt/main.nf
+++ b/nextflow/modules/annotation/ParseAlphaMissenseIntoHt/main.nf
@@ -7,16 +7,19 @@ process ParseAlphaMissenseIntoHt {
 
     input:
         path(am_tsv)
+        path(mane_json)
 
     output:
-        path("alphamissense_38.ht.tar")
+        path("alphamissense_isoforms_38.ht.tar")
 
     script:
         """
         ParseAlphaMissenseIntoHt \
             --am_tsv ${am_tsv} \
-            --ht_out alphamissense_38.ht
-        tar --no-xattrs -cf alphamissense_38.ht.tar alphamissense_38.ht
-        rm -r alphamissense_38.ht
+            --ht_out alphamissense_isoforms_38.ht \
+            --mane_json ${mane_json}
+
+        tar --no-xattrs -cf alphamissense_isoforms_38.ht.tar alphamissense_isoforms_38.ht
+        rm -r alphamissense_isoforms_38.ht
         """
 }


### PR DESCRIPTION
# Fixes

  - AlphaMissense's 'single canonical transcript per gene' file doesn't always contain the MANE transcript as it's chosen one

## Proposed Changes

  - Instead of downloading the smaller AlphaMissense file, this downloads the larger version including multiple isoforms
  - During parsing, we load in the MANE gene lookup file, and only keep AlphaMissense results on MANE transcripts

This was an incidental finding while trying to reconcile some of our missed calls. We're already removing AlphaMissense as a full-strength category, so a logical extra step would be to reduce the number of transcripts we're annotating AlphaMissense consequences for. 

This is just an idea, but if we want to tighten up AM and potentially reintroduce it as a family-only category, we can be selective about the transcripts being considered.

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
