### PR TITLE
Fix: correction to gff3 processing, and better nextflow output management

### DIFF
--- a/nextflow/modules/annotation/ReformatAnnotatedVcfIntoHailTable/main.nf
+++ b/nextflow/modules/annotation/ReformatAnnotatedVcfIntoHailTable/main.nf
@@ -8,10 +8,10 @@ process ReformatAnnotatedVcfIntoHailTable {
         path gene_bed
         path mane
 
-    publishDir params.cohort_output_dir, mode: 'copy'
+    publishDir params.cohort_output_dir, mode: 'link'
 
     output:
-        path "${params.cohort}_annotations.ht.tar"
+        path "${params.cohort}_annotations.ht"
 
     script:
         """
@@ -23,8 +23,6 @@ process ReformatAnnotatedVcfIntoHailTable {
             --gene_bed ${gene_bed} \
             --output ${params.cohort}_annotations.ht \
             --mane ${mane}
-
-        tar --remove-files -cf ${params.cohort}_annotations.ht.tar ${params.cohort}_annotations.ht
 
         # cut down on work folder space
         rm -r alphamissense_38.ht

--- a/nextflow/modules/annotation/ReformatAnnotatedVcfIntoHailTable/main.nf
+++ b/nextflow/modules/annotation/ReformatAnnotatedVcfIntoHailTable/main.nf
@@ -3,15 +3,15 @@ process ReformatAnnotatedVcfIntoHailTable {
     container params.container
 
     input:
-        path(vcf)
-        path(alphamissense)
-        path(gene_bed)
-        path(mane)
+        path vcf
+        path alphamissense
+        path gene_bed
+        path mane
 
     publishDir params.cohort_output_dir, mode: 'copy'
 
     output:
-        path("${params.cohort}_annotations.ht.tar")
+        path "${params.cohort}_annotations.ht.tar"
 
     script:
         """

--- a/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
+++ b/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
@@ -3,18 +3,20 @@ process TransferAnnotationsToMatrixTable {
     container params.container
 
     input:
-        path(compressed_ht)
+        path annotations
         tuple path(vcf), path(tbi)
 
-    publishDir params.cohort_output_dir, mode: 'link'
+    publishDir params.cohort_output_dir, mode: 'move'
 
     output:
-        path("${params.cohort}.mt")
+        path "${params.cohort}.mt"
 
     script:
         """
         set -ex
-        tar --no-same-owner -xf ${compressed_ht}
+
+        tar --no-same-owner -xf ${annotations}
+
         TransferAnnotationsToMatrixTable \
             --input ${vcf} \
             --annotations ${params.cohort}_annotations.ht \

--- a/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
+++ b/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
@@ -15,14 +15,9 @@ process TransferAnnotationsToMatrixTable {
         """
         set -ex
 
-        tar --no-same-owner -xf ${annotations}
-
         TransferAnnotationsToMatrixTable \
             --input ${vcf} \
-            --annotations ${params.cohort}_annotations.ht \
+            --annotations ${annotations} \
             --output ${params.cohort}.mt
-
-        # cut down on work folder space
-        rm -r ${params.cohort}_annotations.ht
         """
 }

--- a/src/talos/annotation_scripts/CreateRoiFromGff3.py
+++ b/src/talos/annotation_scripts/CreateRoiFromGff3.py
@@ -146,8 +146,8 @@ def merge_output(
             # far enough apart, write the previous block and reset
             else:
                 handle.write(f'{contig}\t{start}\t{end}\n')
-                start = min(start, this_start)
-                end = max(end, this_end)
+                start = this_start
+                end = this_end
 
         # and write the final line
         handle.write(f'{contig}\t{start}\t{end}\n')


### PR DESCRIPTION
# Fixes

  - There's a bug in the BED file/region of interest generating script. All the regions have the same start point, so the 'subsetting' is really just thousands of overlapping samples
  - The input/output of the annotation workflow needs to be altered - hard linking creates permissions issues

## Proposed Changes

  - Correction to GFF3 processing script
  - ReformatAnnotatedVcfIntoHailTable: symlinks output (HailTable) to output folder
  - TransferAnnotationsToMatrixTable: output MT is placed in the output folder as a `Move`, not a hard link. Move works with an arbitrarily nested directory. This will mean a second run of the same completed workflow with `-resume` will have to repeat this final step, but if it was successful... why would you resume it

This still assumes a local file system

## Checklist

- [ ] Related Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
