### PR TITLE
Update NF module to COPY MT out

### DIFF
--- a/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
+++ b/nextflow/modules/annotation/TransferAnnotationsToMatrixTable/main.nf
@@ -5,7 +5,7 @@ process TransferAnnotationsToMatrixTable {
         path annotations
         tuple path(vcf), path(tbi)
 
-    publishDir params.cohort_output_dir, mode: 'move'
+    publishDir params.cohort_output_dir, mode: 'copy'
 
     output:
         path "${params.cohort}.mt"


### PR DESCRIPTION
# Fixes

  - Seen in slack https://centrepopgen.slack.com/archives/C08APN7GM7V/p1748990830714699

## Proposed Changes

  - changes the MT extraction method to a copy, matching other outputs - NextFlow _does_ handle a recursive copy by default, so changing this to copy evades permission issues seen previously.