### PR TITLE
Remove "*"-alleles from the dataset

### DIFF
--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -874,6 +874,14 @@ def main(
     mt = hl.read_matrix_table(mt_path)
     logger.info(f'Loaded annotated MT from {mt_path}, size: {mt.count_rows()}, partitions: {mt.n_partitions()}')
 
+    # Filter out star alleles, not currently capable of handling them
+    # Will revisit once our internal experience with DRAGEN-generated variant data improves
+    logger.info('Removing any star-allele sites from the dataset, Talos is not currently designed to handle these')
+    mt = mt.filter_rows(
+        mt.alleles.contains('*'),
+        keep=False,
+    )
+
     # insert AC/AN/AF if missing
     mt = populate_callset_frequencies(mt)
 

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -884,7 +884,7 @@ def main(
     # this creates a local duplicate of the input data with far smaller partition counts, for less processing overhead
     if mt.n_partitions() > MAX_PARTITIONS:
         logger.info('Shrinking partitions way down with an unshuffled repartition')
-        mt = mt.repartition(shuffle=False, n_partitions=number_of_cores * 10)
+        mt = mt.repartition(shuffle=False, n_partitions=200)
         if checkpoint:
             logger.info('Trying to write the result locally, might need more space on disk...')
             mt = generate_a_checkpoint(mt, f'{checkpoint}_repartitioned')

--- a/src/talos/RunHailFiltering.py
+++ b/src/talos/RunHailFiltering.py
@@ -855,12 +855,7 @@ def main(
     ███      ███     ███   ███      █  ███     ███  ███     ███
    █████    █████   █████ ███████████    ███████     █████████""",
     )
-
-    # initiate Hail as a local cluster
-    number_of_cores = config_retrieve(['RunHailFiltering', 'cores', 'small_variants'], 8)
-    logger.info(f'Starting Hail with reference genome GRCh38, as a {number_of_cores} core local cluster')
-
-    hl.context.init_spark(master=f'local[{number_of_cores}]', default_reference='GRCh38', quiet=True)
+    hl.context.init_spark(master='local[*]', default_reference='GRCh38', quiet=True)
 
     # read the parsed panelapp data
     logger.info(f'Reading PanelApp data from {panel_data!r}')

--- a/src/talos/RunHailFilteringSv.py
+++ b/src/talos/RunHailFilteringSv.py
@@ -252,7 +252,7 @@ def main(vcf_path: str, panelapp_path: str, mane_json: str, pedigree: str, vcf_o
     green_expression = green_from_panelapp(panelapp)
 
     # initiate Hail in local cluster mode
-    logger.info(f'Starting Hail with reference genome GRCh38, as a local cluster')
+    logger.info('Starting Hail with reference genome GRCh38, as a local cluster')
     hl.context.init_spark(master='local[*]')
     hl.default_reference('GRCh38')
 

--- a/src/talos/RunHailFilteringSv.py
+++ b/src/talos/RunHailFilteringSv.py
@@ -252,9 +252,8 @@ def main(vcf_path: str, panelapp_path: str, mane_json: str, pedigree: str, vcf_o
     green_expression = green_from_panelapp(panelapp)
 
     # initiate Hail in local cluster mode
-    number_of_cores = config_retrieve(['RunHailFiltering', 'cores', 'sv'], 4)
-    logger.info(f'Starting Hail with reference genome GRCh38, as a {number_of_cores} core local cluster')
-    hl.context.init_spark(master=f'local[{number_of_cores}]')
+    logger.info(f'Starting Hail with reference genome GRCh38, as a local cluster')
+    hl.context.init_spark(master='local[*]')
     hl.default_reference('GRCh38')
 
     # read the VCF in as a MatrixTable, and checkpoint it locally
@@ -263,7 +262,6 @@ def main(vcf_path: str, panelapp_path: str, mane_json: str, pedigree: str, vcf_o
         reference_genome='GRCh38',
         skip_invalid_loci=True,
         force_bgz=True,
-        n_partitions=number_of_cores,
     ).checkpoint(
         output='temporary.mt',
         _read_if_exists=True,

--- a/src/talos/example_config.toml
+++ b/src/talos/example_config.toml
@@ -116,9 +116,6 @@ max_depth = 1000
 min_gq = 25
 min_alt_depth = 5
 
-[RunHailFiltering.cores]
-small_variants = 8
-
 [categories]
 1 = 'ClinVar Pathogenic'
 3 = 'High Impact Variant'


### PR DESCRIPTION
# Fixes

  - Talos' de novo detection method has poor tolerance for spanning deletions, or any other scenarios which can result in an single-length AD (Allele Depth) array.

## Proposed Changes

  - Inserts a strict filter for spanning alleles, and a logging message to acknowledge their removal from the dataset 
  - see https://gatk.broadinstitute.org/hc/en-us/articles/360035531912-Spanning-or-overlapping-deletions-allele
  - If these sites are still problematic, complete avoidance of this process can be done through configurable skipping of the whole de novo category