### PR TITLE
Skip over parents without a row in the pedigree

### DIFF
--- a/src/talos/moi_tests.py
+++ b/src/talos/moi_tests.py
@@ -447,7 +447,7 @@ class BaseMoi:
         sample_ped_entry = self.pedigree.by_id[sample_id]
         for parent in [sample_ped_entry.mother, sample_ped_entry.father]:
             # skip to prevent crashing on !trios
-            if parent is None:
+            if parent is None or (parent not in self.pedigree.by_id):
                 continue
 
             if ((parent in variant_1.het_samples) and (parent in variant_2.het_samples)) or self.pedigree.by_id[


### PR DESCRIPTION
# Fixes

  - If a parent is in the pedigree as a mother/father, but not as their own row, we try to retrieve their affected status during comp-het testing, and fail as a result
  - Ideal fix is to have the pedigree file limited to members in the callset for clarity, but that's going to be addressed in an upcoming change.

## Proposed Changes

  - During Comp-Het test, we skip any participants which are missing from the pedigree
  - No need to check for this in other places - the callsets are filtered down to samples in the pedigree (samples with a private row, not just referenced as a relative) so this is fairly safe.