### PR TITLE
Two quick fixes

### DIFF
--- a/src/talos/cpg_internal_scripts/cpg_flow_utils.py
+++ b/src/talos/cpg_internal_scripts/cpg_flow_utils.py
@@ -6,6 +6,7 @@ from cpg_utils import Path, config, to_path
 
 from metamist import graphql
 
+
 LONG_READ_STRING = 'LongRead'
 METAMIST_ANALYSIS_QUERY = graphql.gql(
     """
@@ -99,7 +100,7 @@ def query_for_latest_analysis(
                 continue
 
             # manually implementing an XOR check - long read (bool) and LongRead in output must match
-            if long_read != LONG_READ_STRING in analysis['output']:
+            if long_read != (LONG_READ_STRING in analysis['output']):
                 loguru.logger.debug(
                     f'Skipping analysis {analysis["output"]} for dataset {query_dataset}. '
                     f'It does not match query parameter long_read={long_read}',

--- a/src/talos/cpg_internal_scripts/cpg_flow_utils.py
+++ b/src/talos/cpg_internal_scripts/cpg_flow_utils.py
@@ -6,7 +6,6 @@ from cpg_utils import Path, config, to_path
 
 from metamist import graphql
 
-
 LONG_READ_STRING = 'LongRead'
 METAMIST_ANALYSIS_QUERY = graphql.gql(
     """


### PR DESCRIPTION
# Fixes

  - Re-adds the 'remove genes from analysis if they needed a phenotype match but were only on the mendeliome' behaviour
  - Correction to a boolean condition I swear I tested, which governs which MTs are picked up when running LongRead analysis