### PR TITLE
Everything is a db... 

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -45,14 +45,14 @@ This document explains the configuration options, the default values, and sensib
   * Config Section: `RunHailFiltering.de_novo`
   * Description: Controls filtering thresholds and de novo variant detection parameters during the Hail Stage
 
-| Field            | Purpose                                                                                                                                                         | Default | Alternative |
-|------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-------------|
-| `min_child_ab`   | Minimum proportion of alt-supporting reads relative to overall read depth for the proband                                                                       | 0.20    |             |
-| `min_depth`      | Minimum read depth for calls. In order of preference/availability this is from `DP`, total of `AD`, or if both are absent, a dummy value which will always pass | 5       |             |
-| `max_depth`      | Maximum read depth for calls. In order of preference/availability this is from `DP`, total of `AD`, or if both are absent, a dummy value which will always pass | 1000    |             |
-| `min_alt_depth`  | If all other conditions succeed, at least this many Alt observations to confirm a de Novo call                                                                  | 5       |             |
-| `min_proband_gq` | Minumum genotype quality score for all variants in probands/affected participants (detected via Pedigree)                                                       | 25      | 40          |
-| `min_all_sample_gq`  | Minimum GQ applied to all samples                                                                                                                               | 5       |             |
+| Field                | Purpose                                                                                                                                                         | Default | Alternative |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-------------|
+| `min_child_ab`       | Minimum proportion of alt-supporting reads relative to overall read depth for the proband                                                                       | 0.20    |             |
+| `min_depth`          | Minimum read depth for calls. In order of preference/availability this is from `DP`, total of `AD`, or if both are absent, a dummy value which will always pass | 5       |             |
+| `max_depth`          | Maximum read depth for calls. In order of preference/availability this is from `DP`, total of `AD`, or if both are absent, a dummy value which will always pass | 1000    |             |
+| `min_alt_depth`      | If all other conditions succeed, at least this many Alt observations to confirm a de Novo call                                                                  | 5       |             |
+| `min_proband_gq`     | Minumum genotype quality score for all variants in probands/affected participants (detected via Pedigree)                                                       | 25      | 40          |
+| `min_all_sample_gq`  | Minimum GQ applied to all samples                                                                                                                               | 15      |             |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies=[
     'pydantic>=2.5.2',
     'python-dateutil>=2',
     'semsimian',
+    'sqlalchemy',
     'tabulate>=0.8.9',
     'tenacity>=9.0.0',
     'toml==0.10.2',

--- a/src/talos/db/create_sqlite_db.py
+++ b/src/talos/db/create_sqlite_db.py
@@ -122,22 +122,7 @@ for participant in result:
 
         # now maybe I want to update the report event with an additional category
         if 'new_category' not in var.ReportEvent.categories:
-            var.ReportEvent.categories['new_category'] = '2025-03-01'
-
-        print(f'New categories: {var.ReportEvent.categories}')
-
-        # update it through the update & params
-        _SESSION.execute(
-            update(ReportEvent),
-            [
-                {
-                    'evidence_last_updated': max(var.ReportEvent.categories.values()),
-                    'categories': var.ReportEvent.categories,
-                    'id': var.ReportEvent.id,
-                }
-            ],
-        )
-        _SESSION.commit()
+            var.ReportEvent.add_categories(['new_category', 'another_category'], _SESSION)
 
 # just to make sure it updated
 reportevent_check = _SESSION.execute(select(ReportEvent).where(ReportEvent.id == reportevent1.id)).scalar_one()

--- a/src/talos/db/create_sqlite_db.py
+++ b/src/talos/db/create_sqlite_db.py
@@ -1,0 +1,162 @@
+"""
+demonstration in two parts for the creation of a db schema, and the creation of the db itself
+the accompanying file create_sqlite_schema.py contains the schema definition
+"""
+
+from talos.db.create_sqlite_schema import (
+    Base,
+    Family,
+    Participant,
+    Decision,
+    Proband,
+    Variant,
+    TranscriptConsequence,
+    ReportEvent,
+    Run,
+)
+
+from sqlalchemy import create_engine, select, join, update
+from sqlalchemy.orm.session import Session
+
+from cloudpathlib.anypath import to_anypath
+
+_SESSION: Session | None = None
+
+
+def main():
+    """
+    if the db exists, just connect to it. If this is the first time creation, create the tables.
+    Returns:
+
+    """
+    db_name = 'test.db'
+    # record whether the db already exists, or is a first time creation
+    db_exists = to_anypath(db_name).exists()
+
+    engine = create_engine('sqlite+pysqlite:///test.db')
+    session = Session(engine)
+
+    if not db_exists:
+        print('creating new db tables from imported schema')
+        Base.metadata.create_all(engine)
+
+    global _SESSION
+    _SESSION = session
+
+
+main()
+
+# some examples of how this would work
+f1 = Family(id='FAM1')
+_SESSION.add(f1)
+p1 = Participant(
+    id='P1',
+    family=f1.id,
+    ext_id='EXT1',
+    affected=True,
+)
+_SESSION.add(p1)
+
+pro1 = Proband(
+    id=p1.id,
+    solved=False,
+)
+_SESSION.add(pro1)
+
+var1 = Variant(
+    chromosome='chr1',
+    position=123456,
+    reference='A',
+    alternate='T',
+)
+_SESSION.add(var1)
+
+txcsq1 = TranscriptConsequence(
+    variant=var1,
+    gene_symbol='GENE1',
+    consequence='missense_variant',
+)
+_SESSION.add(txcsq1)
+
+# autoincrementing IDs are assigned on commit, so this needs to be pushed before the foreign key relationships can exist
+_SESSION.commit()
+
+reportevent1 = ReportEvent(
+    proband_id=pro1.id,
+    variant_id=var1.id,
+    moi_satisfied='Initial population',
+    panels={1, 2, 3},
+    genotype_proband='0/1',
+    categories={'alphamissense': '2025-02-14'},
+)
+
+_SESSION.add(reportevent1)
+
+_SESSION.commit()
+
+# query for the family, scalar_one() raises if not exactly one result
+family_result = _SESSION.execute(select(Family).where(Family.id == 'FAM1')).scalar_one()
+print(f'Family ID: {family_result.id}')
+
+# join probands to participants, and filter by family id
+result = _SESSION.execute(
+    select(Proband, Participant).join(Proband.proband).where(Participant.family == family_result.id)
+)
+
+# iterate over the probands in the family
+for participant in result:
+    print(f'Participant ID: {participant.Participant.id}, EXT ID: {participant.Participant.ext_id}')
+    for var in _SESSION.execute(
+        select(ReportEvent).where(ReportEvent.proband_id == participant.Participant.id),
+    ):
+        print(f'  Reported variant ID: {var.ReportEvent.variant_id}')
+        print(f'  Categories: {var.ReportEvent.categories}')
+
+        # query back down to the transcript consequences - would be populated at runtime, and pulled to generate HTML
+        for tx in _SESSION.execute(
+            select(TranscriptConsequence).where(TranscriptConsequence.variant_id == var.ReportEvent.variant_id),
+        ):
+            print(
+                f'    Gene: {tx.TranscriptConsequence.gene_symbol}, consequence: {tx.TranscriptConsequence.consequence}'
+            )
+
+        # now maybe I want to update the report event with an additional category
+        var.ReportEvent.categories['new_category'] = '2025-03-01'
+        print(var.ReportEvent.categories)
+
+        # update it through the update & params
+        _SESSION.execute(
+            update(ReportEvent),
+            [
+                {
+                    'evidence_last_updated': max(var.ReportEvent.categories.values()),
+                    'categories': var.ReportEvent.categories,
+                    'id': var.ReportEvent.id,
+                }
+            ],
+        )
+        _SESSION.commit()
+
+# just to make sure it updated
+reportevent_check = _SESSION.execute(select(ReportEvent).where(ReportEvent.id == reportevent1.id)).scalar_one()
+print(f'Updated categories: {reportevent_check.categories}')
+print(f'Updated date: {reportevent_check.evidence_last_updated}')
+
+# record a new decision
+decision = Decision(
+    report_event_id=reportevent_check.id,
+    decision='pathogenic',
+    notes='I decided that this is bad',
+)
+_SESSION.add(decision)
+_SESSION.commit()
+
+# select it back
+decision_check = _SESSION.execute(select(Decision).where(Decision.id == decision.id)).scalar_one()
+print(f'Decision recorded: {decision_check.decision}, notes: {decision_check.notes}')
+
+
+_SESSION.close()
+
+# sqlalchemy doesn't have a built-in get_or_create, but it's easy enough to do with a select and an add if not found
+# https://stackoverflow.com/questions/2546207/does-sqlalchemy-have-an-equivalent-of-djangos-get-or-create

--- a/src/talos/db/create_sqlite_db.py
+++ b/src/talos/db/create_sqlite_db.py
@@ -3,22 +3,20 @@ demonstration in two parts for the creation of a db schema, and the creation of 
 the accompanying file create_sqlite_schema.py contains the schema definition
 """
 
-from talos.db.create_sqlite_schema import (
-    Base,
-    Family,
-    Participant,
-    Decision,
-    Trio,
-    Variant,
-    TranscriptConsequence,
-    ReportEvent,
-    Run,
-)
-
-from sqlalchemy import create_engine, select, join, update, insert
+from cloudpathlib.anypath import to_anypath
+from sqlalchemy import create_engine, insert, select
 from sqlalchemy.orm.session import Session
 
-from cloudpathlib.anypath import to_anypath
+from talos.db.create_sqlite_schema import (
+    Base,
+    Decision,
+    Family,
+    Participant,
+    ReportEvent,
+    TranscriptConsequence,
+    Trio,
+    Variant,
+)
 
 _SESSION: Session | None = None
 
@@ -45,6 +43,9 @@ def main():
 
 
 main()
+
+if _SESSION is None:
+    raise RuntimeError('session not created')
 
 # some examples of how this would work
 f1 = Family(id='FAM1')
@@ -86,7 +87,7 @@ var1 = _SESSION.execute(
         (Variant.chromosome == 'chr1')
         & (Variant.position == 123456)
         & (Variant.reference == 'A')
-        & (Variant.alternate == 'T')
+        & (Variant.alternate == 'T'),
     ),
 ).scalar_one()
 
@@ -136,7 +137,7 @@ for participant in result:
             select(TranscriptConsequence).where(TranscriptConsequence.variant_id == var.ReportEvent.variant_id),
         ):
             print(
-                f'    Gene: {tx.TranscriptConsequence.gene_symbol}, consequence: {tx.TranscriptConsequence.consequence}'
+                f'   Gene: {tx.TranscriptConsequence.gene_symbol}, consequence: {tx.TranscriptConsequence.consequence}',
             )
 
         print(var.ReportEvent.categories)

--- a/src/talos/db/create_sqlite_schema.py
+++ b/src/talos/db/create_sqlite_schema.py
@@ -1,0 +1,235 @@
+from typing import List
+from sqlalchemy.schema import ForeignKey, UniqueConstraint
+from sqlalchemy.types import PickleType, String, Integer, Float, Boolean
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from talos.static_values import get_granular_date
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Family(Base):
+    """
+    a family ID, used as a foreign key to collect all family members, nothing major here, just simplifies queries
+    """
+
+    __tablename__ = 'family'
+    id: Mapped[str] = mapped_column(String(50), primary_key=True, unique=True)
+
+
+class Participant(Base):
+    """
+    atomic description of a participant, no relationships
+    we could add name, age, etc. but these aren't important for Talos
+    """
+
+    __tablename__ = 'participant'
+    # id = Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True, nullable=False)
+
+    # the sample ID we would expect in the VCF
+    id: Mapped[str] = mapped_column(String(50), primary_key=True, unique=True)
+
+    # these two attributes are probably also unique, but not primary keys as they can be null
+    ext_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # seqr ID is actually at the family level, but that's not important here, it still applies to the proband
+    seqr_id: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    family: Mapped[str | None] = mapped_column(String(50), ForeignKey('family.id'), nullable=True)
+
+    # boolean
+    affected: Mapped[bool] = mapped_column(nullable=False, default=False)
+
+    # embedded python set type, nullable. to be populated from the pedigree
+    hpo_terms: Mapped[set[str] | None] = mapped_column(PickleType, nullable=True)
+
+
+class Proband(Base):
+    """
+    Affected members and immediate family context. Each row represents a nuclear trio used in inheritance filtering
+    What happens if we previously had a proband, and in a new run we have parents? Detect and update?
+    """
+
+    __tablename__ = 'proband'
+    # with multiple foreign keys to the participant table, we need to explicitly define the foreign_keys in the relationship
+    id: Mapped[str] = mapped_column(String(50), ForeignKey('participant.id'), primary_key=True, unique=True)
+    proband = relationship('Participant', foreign_keys=[id])
+    mother_id: Mapped[str | None] = mapped_column(String(50), ForeignKey('participant.id'), nullable=True)
+    mother = relationship('Participant', foreign_keys=[mother_id])
+    father_id: Mapped[str | None] = mapped_column(String(50), ForeignKey('participant.id'), nullable=True)
+    father = relationship('Participant', foreign_keys=[father_id])
+
+    # at the affected participant/proband level, we can track whether the case has been solved
+    # this is discrete from the particpant level affected status, and the family (could have multiple affected members)
+    # this can be accompanied by a solved_by foreign key to a decision - the variant plus notes
+    solved: Mapped[bool | None] = mapped_column(Boolean, default=False)
+    solved_by: Mapped[int | None] = mapped_column(Integer, ForeignKey('decision.id'), nullable=True)
+
+
+class Variant(Base):
+    """
+    A variant seen in any participant.
+    We could add more fields if we want to track them.
+    """
+
+    __tablename__ = 'variant'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True, nullable=False)
+    chromosome: Mapped[str] = mapped_column(String(5), nullable=False)
+    position: Mapped[int] = mapped_column(Integer, nullable=False)
+    reference: Mapped[str] = mapped_column(String(500), nullable=False)
+    alternate: Mapped[str] = mapped_column(String(500), nullable=False)
+
+    # small, str, mito, cnv, sv, etc.
+    var_type: Mapped[str | None] = mapped_column(String(20), default='small')
+
+    # relatively fixed annotations. Not currently checking multiple discrete populations, though we could.
+    gnomad_af: Mapped[float | None] = mapped_column(Float, nullable=True)
+    gnomad_ac: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    gnomad_an: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    gnomad_homalt: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # multiple foreign key connections to the TX consequences for this variant
+    transcript_consequence: Mapped[List['TranscriptConsequence']] = relationship(back_populates='variant')
+
+    # SpliceAI can be 4 separate scores, but currently we only have one (or none by default)
+    # we're currently getting SpliceAI scores at the variant level, not the transcript level
+    spliceai: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # clinvar related attributes - significance, stars, date of review status increase (all nullable)
+    clinvar_clinsig: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    clinvar_stars: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    clinvar_increased: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    # ensure uniqueness on the combination [chromosome, position, reference, alternate]
+    __table_args__ = (UniqueConstraint('chromosome', 'position', 'reference', 'alternate', name='variant_unique'),)
+
+    def __repr__(self) -> str:
+        return f'{self.chromosome}-{self.position}-{self.reference}-{self.alternate}'
+
+
+class TranscriptConsequence(Base):
+    """
+    Each transcript consequence, many-to-one:variant relationship.
+    We could add more fields if we want to track them.
+    """
+
+    __tablename__ = 'transcript_consequence'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    variant_id: Mapped[int] = mapped_column(ForeignKey('variant.id'))
+    variant: Mapped['Variant'] = relationship(back_populates='transcript_consequence')
+
+    # broadly this matches the fields obtained from bcftools, VEP, and/or ANNOVAR
+    gene_symbol: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    ensg: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    enst: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    ensp: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    dna_change: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    amino_acid_change: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    codon: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    exon: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    mane_id: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    mane_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+
+    alphamissense_class: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    alphamissense_pathogenicity: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    # not including alphagenome yet, it has too many scores and too much variability, requires more thought
+
+    # the bcftools/VEP consequence term(s), comma-separated if multiple
+    consequence: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    # contains the clinvar PM5 details, if applicable
+    clinvar_pm5: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+
+class ReportEvent(Base):
+    """
+    A record of an event in the report generation process, a variant, the family it was seen in, genotypes, and categories.
+    We can revisit the same event later, if it is seen with different (additional) categories.
+    """
+
+    __tablename__ = 'report_event'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    timestamp: Mapped[str] = mapped_column(String(50), nullable=False, default=get_granular_date())
+    proband_id: Mapped[str] = mapped_column(String(50), ForeignKey('proband.id'), nullable=False)
+    variant_id: Mapped[str] = mapped_column(String(50), ForeignKey('variant.id'), nullable=False)
+    # optional for comp-het pairs
+    second_variant_id: Mapped[str | None] = mapped_column(String(50), ForeignKey('variant.id'), nullable=True)
+    # the MOI model which was satisfied for this event
+    moi_satisfied: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    # optional, any filters or AB test failures which should be noted for the variant
+    flags: Mapped[set[str] | None] = mapped_column(PickleType, nullable=True)
+
+    # a collection of all the panels applied to this proband containing this gene
+    panels: Mapped[set[int] | None] = mapped_column(PickleType, nullable=True)
+
+    # # maybe? a dict of IDs to genotypes?
+    # genotypes: Mapped[Optional[dict[str, str]]] = mapped_column(PickleType, nullable=True)
+    # # or this? splitting the nuclear family genotypes out into separate fields. This is a bit limiting, but simpler.
+    genotype_proband: Mapped[str] = mapped_column(String(10), nullable=False)
+    genotype_mother: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    genotype_father: Mapped[str | None] = mapped_column(String(10), nullable=True)
+
+    # todo store depth and AB info?
+
+    # a dictionary of categories, and dates of first discovery, can be updated.
+    # this format is something SQLalchemy can handle fine, but requires the field being replaced with each change.
+    categories: Mapped[dict[str, str]] = mapped_column(PickleType, nullable=False)
+
+    callset_af: Mapped[float | None] = mapped_column(Float, nullable=True)
+    callset_ac: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    callset_an: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # collect HPO terms and/or panels that matched this variant gene to the proband
+    forced_match_panel: Mapped[set[str] | None] = mapped_column(PickleType, nullable=True)
+    pheno_match_hpo: Mapped[set[str] | None] = mapped_column(PickleType, nullable=True)
+    pheno_match_panels: Mapped[set[str] | None] = mapped_column(PickleType, nullable=True)
+
+    # date of first phenomatch discovery, if any
+    first_pheno_match: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    evidence_last_updated: Mapped[str | None] = mapped_column(String(50), nullable=True)
+
+    __table_args__ = (UniqueConstraint('variant_id', 'second_variant_id', 'moi_satisfied', name='variant_moi_unique'),)
+
+
+class Decision(Base):
+    """
+    A record of a decision made on a report event, with a timestamp and optional notes.
+    In case of an interactive application, the use-case here would be to track changes to decisions over time.
+    A user could select the variant event, make a decision, and add notes.
+    We could add a user ID if we want to track who made the decision, though that would require a user table and login.
+    """
+
+    __tablename__ = 'decision'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # the report event table connects the proband, variant, genotypes, categories, etc.
+    report_event_id: Mapped[int] = mapped_column(Integer, ForeignKey('report_event.id'), nullable=False)
+
+    timestamp: Mapped[str] = mapped_column(String(50), default=get_granular_date())
+
+    # e.g., 'causative', 'phenotype expansion', 'artefact'. Could be an enum if we want to restrict values.
+    decision: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    # extended opportunity for notes, nullable. This is analogous to the Seqr notes field.
+    notes: Mapped[str | None] = mapped_column(String(500), nullable=True)
+
+
+class Run(Base):
+    """
+    A record of Talos runs on a cohort, with parameters and a timestamp.
+    We could add a JSON field for parameters if we want to track them.
+    We could also tag each first-time variant appearance with the run ID.
+    """
+
+    __tablename__ = 'run'
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    timestamp: Mapped[str] = mapped_column(String(50), default=get_granular_date())
+    version: Mapped[str] = mapped_column(String(50), nullable=False)

--- a/src/talos/db/create_sqlite_schema.py
+++ b/src/talos/db/create_sqlite_schema.py
@@ -1,7 +1,7 @@
 from sqlalchemy import update
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.orm.session import Session
-from sqlalchemy.schema import ForeignKey, UniqueConstraint, Index
+from sqlalchemy.schema import ForeignKey, Index
 from sqlalchemy.types import Boolean, Float, Integer, PickleType, String
 
 from talos.static_values import get_granular_date


### PR DESCRIPTION
This isn't a full implementation, it's just kicking tires on SQLalchemy, and sketching out a database design for discussion

# Purpose

  - To date Talos has maintained two main objects:
    - a set of JSON results, representing the outcome of a single Talos run
    - a set of History files, representing the outcome of previous Talos runs

This is messy, causes very specific problems around containerised infrastructure, and is hard to move on from (e.g. if we want a web app to present the data in a scalable reactive way we need to move on from JSON files, and if we want to enable feedback on individual variants, that would require an additional object/db to be created)  

#588 was a PR addressing the first part of that problem: turning the history files into a database, but it doesn't go far enough. That still leaves us with history, results, and potentially feedback in 3 separate data stores.

This suggests going further, implementing the history, results, and feedback mechanism into a single unified database. The Schema makes space for all the things we currently store in JSON (participants, family structures, variants, variant annotations, categories and their dates of first assignment, ...), and makes room for some more (a table to record dates/software versions for when Talos was run, a table for logging decisions made by analysts, allowing a participant to be 'solved' by linking a reported event with a proband and a free text field, or a variant to be marked as irrelevant/artifact).

The dream here would be a single file (if a freestanding sqlite db) or a database (if we up our game), where Talos would incrementally update with new findings, without having to write a whole new set of results with each run. No need to track a history separately, the dates are all in the main database. No need to write a second report after the HPO matching is done, we just update the variants we already found with phenotype matches. The Jinja templates can be populated directly from the database, or at some point we could shift to javascript in the web page interacting directly with the database.

Instead of redundantly storing the same variant annotations with each instance of the variant, this has the potential to shrink the overall data footprint of the JSON reports, whilst being far more searchable. 

This version is implemented in SQLite, which saves on the complexity of running a DBMS either in the container or externally. That could be altered at some point in the future. 

Instead of naked queries it's implemented in SQLalchemy (a change to a proper DBMS wouldn't require a change in (much) code). That also enables the embedding of python objects (dicts, sets, lists) as attributes using the PickleType.

SQLite doesn't have a notion of migrations, so we'd have to keep track of any changes to this model. Worst case scenario involves creating completely new tables and schemas, reading old data -> new table, and swapping the table to the original name. A better database tech would have the ability to update/alter tables in place, but this doesn't currently need those features.

  - Schema for consideration and development, does this include everything a Talos.db needs for now? 

## Proposed Changes

  - an SQLite/SQLAlchemy database schema
  - create_sqlite_schema.py contains the schema, defined in terms of SQLalchemy classes and their relationships
  - create_sqlite_db.py is an example of the database being instantiated if it doesn't exist, then some insertions/queries/updates on the contents using sqlalchemy object methods

The create_sqlite_db.py can be run locally with just sqlalchemy as a dependency, feel free to kick it about and see how it feels

![my_data_model_diagram](https://github.com/user-attachments/assets/0e5f3b64-f863-4df7-9803-bfbcccf0f50f)
