### PR TITLE
Insert AC/AF/AN attributes in the pre-merged VCF path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Talos requires several large external resources (e.g. reference genome, gnomAD, 
 
 ### **3. Run Annotation Workflow**
 
-This step pre-processes and annotates variants. This workflow only needs to be run once per dataset. This can either begin with single-sample VCFs, or a pre-merged multi-sample VCF. If you have a pre-merged VCF, pass into the workflow with `--merged_vcf <path>`:
+This step pre-processes and annotates variants. This workflow only needs to be run once per dataset. This can either begin with single-sample VCFs, or a pre-merged multi-sample VCF. If you have a pre-merged VCF, pass into the workflow with `--merged_vcf <path>` (AC/AF/AN values for each variant will be added to the VCF based on the subset of samples present. If you would like to provide this allele frequency data from an alternate source please raise an issue, and we can look into this):
 
 ```
 nextflow -c nextflow/annotation.config \

--- a/nextflow/modules/annotation/FilterVcfToBedWithBcftools/main.nf
+++ b/nextflow/modules/annotation/FilterVcfToBedWithBcftools/main.nf
@@ -23,9 +23,11 @@ process FilterVcfToBedWithBcftools {
     bcftools norm \
     	-m -any \
     	-f ${ref_genome} \
-        --write-index=tbi \
         -R ${bed_file} \
-        -Oz -o "${params.cohort}_merged_filtered.vcf.bgz" \
-        ${vcf}
+        -Ou ${vcf} | \
+    bcftools +fill-tags \
+        -Oz \
+        -o "${params.cohort}_merged_filtered.vcf.bgz" \
+        -W=tbi - -- -t AC,AF,AN
     """
 }

--- a/nextflow/modules/annotation/MergeVcfsWithBcftools/main.nf
+++ b/nextflow/modules/annotation/MergeVcfsWithBcftools/main.nf
@@ -38,6 +38,6 @@ process MergeVcfsWithBcftools {
 			-Ou \
 			-f ${ref_genome} \
 			- | \
-        bcftools +fill-tags -Oz -o "${params.cohort}_merged.vcf.bgz" -W=tbi - -- -t AF
+        bcftools +fill-tags -Oz -o "${params.cohort}_merged.vcf.bgz" -W=tbi - -- -t AC,AF,AN
         """
 }


### PR DESCRIPTION
# Fixes

  - When data is provided directly using the `--merged_vcf` route, we didn't insert `AC/AF/AN` values in the INFO field
  - We would expect most variant callers to populate these fields, but they're not mandatory, so this probably isn't a wise assumption to make
  - Since inserting a fail-early module in the Talos workflow to ensure all required fields are present, this now causes the pipeline to fail for users who took the pre-merged path, but didn't have `INFO.AC/AF/AN` populated. 

## Proposed Changes

  - For the `merged_vcf` route we insert AC/AF/AN values when filtering down to a pre-defined BED region, README updated to explain this
  - In future if users want an alternative source of AC/AN/AF or to use pre-embedded values, we can discuss how to do that
