### PR TITLE
Remove —no-version from annotateCSQ

### DIFF
--- a/nextflow/modules/annotation/AnnotateCsqWithBcftools/main.nf
+++ b/nextflow/modules/annotation/AnnotateCsqWithBcftools/main.nf
@@ -14,8 +14,8 @@ process AnnotateCsqWithBcftools {
 
     script:
     """
-    bcftools index --no-version -t ${vcf}
-    bcftools csq --no-version --force -f "${reference}" \
+    bcftools index -t ${vcf}
+    bcftools csq --force -f "${reference}" \
         --local-csq \
         -g ${gff3} \
         -B 20 \

--- a/src/talos/cpg_internal_scripts/talos_stages.py
+++ b/src/talos/cpg_internal_scripts/talos_stages.py
@@ -276,7 +276,6 @@ class AnnotateAndLabelMito(stage.CohortStage):
         if not query_for_latest_analysis(
             dataset=cohort.dataset.name,
             analysis_type='vcf',
-            sequencing_type=config.config_retrieve(['workflow', 'sequencing_type']),
             long_read=config.config_retrieve(['workflow', 'long_read'], False),
             stage_name='GenerateMitoJointCall',
         ):
@@ -303,7 +302,6 @@ class AnnotateAndLabelMito(stage.CohortStage):
         mito_vcf = query_for_latest_analysis(
             dataset=cohort.dataset.name,
             analysis_type='vcf',
-            sequencing_type=config.config_retrieve(['workflow', 'sequencing_type']),
             long_read=config.config_retrieve(['workflow', 'long_read'], False),
             stage_name='GenerateMitoJointCall',
         )
@@ -579,7 +577,6 @@ class ValidateVariantInheritance(stage.CohortStage):
             query_for_latest_analysis(
                 dataset=cohort.dataset.name,
                 analysis_type='vcf',
-                sequencing_type=config.config_retrieve(['workflow', 'sequencing_type']),
                 long_read=config.config_retrieve(['workflow', 'long_read'], False),
                 stage_name='GenerateMitoJointCall',
             )


### PR DESCRIPTION
Adding a `--no-version` command to bcftools index isn't valid, remove that

Mito VCF detection needs a tweak